### PR TITLE
fix(build): remove node 12 support

### DIFF
--- a/.github/workflows/commit_lint.yml
+++ b/.github/workflows/commit_lint.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [14.x]
+        node-version: [16.x]
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 16.x]
+        node-version: [14.x, 16.x]
     steps:
       - uses: actions/checkout@v2
       - name: Setup Node.js ${{ matrix.node-version }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ commit messaging follow the format
 
 ### Build Requirements
 To setup your work environment you'll need to use
- * [NodeJS version 12+](https://nodejs.org/)
+ * [NodeJS version 14+](https://nodejs.org/)
  * [Yarn 1.22+](https://yarnpkg.com)
  * And if you plan on making container contributions you may want to setup
     - [Docker](https://docs.docker.com/engine/installation/) or

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ a delay to see how your codebase will handle loading scenarios with a balls slow
 
 ## Requirements
 The basic requirements:
- * [NodeJS version 12+](https://nodejs.org/)
+ * [NodeJS version 14+](https://nodejs.org/)
  * Optionally your system could be running
     - [Yarn 1.22+](https://yarnpkg.com), otherwise NPM should be adequate.
     - [Docker](https://docs.docker.com/engine/installation/)

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "url": "https://github.com/cdcabrera/apidoc-mock/issues"
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "bin": {
     "mock": "./bin/cli.js"


### PR DESCRIPTION
## What's included
<!-- List your changes/additions, or commits -->
- fix(build): remove node 12 support

### Notes
- Merging this update will create a `5.0` release of apidoc-mock
- action settings will need to be adjusted for the required versions of node
<!-- Anything funky about your updates. Or issues that aren't resolved by this merge request, things of note? -->

## How to test
<!-- Are there directions to test/review? -->

### Coverage and basic unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test`
1. confirm tests come back clean
<!--
### Interactive unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test:dev`
-->
...

## Example
<!-- Append a demo/screenshot/animated gif, or a link to the aforementioned, of the cli output -->
...

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
Ongoing