### PR TITLE
feat(cli): expose apidoc option, silent

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ or Yarn
   Options:
     -d, --docs     Output directory used to compile apidocs   [default: "./.docs"]
     -p, --port     Set mock port                                   [default: 8000]
+    -s, --silent   Silence apiDoc's output warnings, errors
+                                                         [boolean] [default: true]
     -w, --watch    Watch single, or multiple directories
     -h, --help     Show help                                             [boolean]
     -v, --version  Show version number                                   [boolean]

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -6,7 +6,7 @@ const packageJson = require('../package');
 const { logger } = require('../src/logger/configLogger');
 const { apiDocMock } = require('../src');
 
-const { port, watch, docs } = yargs
+const { port, silent, watch, docs } = yargs
   .usage('Create a mock server from apiDoc comments.\n\nUsage: mock [options]')
   .help('help')
   .alias('h', 'help')
@@ -24,6 +24,12 @@ const { port, watch, docs } = yargs
     describe: 'Set mock port',
     requiresArg: true
   })
+  .option('s', {
+    alias: 'silent',
+    default: true,
+    describe: "Silence apiDoc's output warnings, errors",
+    type: 'boolean'
+  })
   .option('w', {
     alias: 'watch',
     describe: 'Watch single, or multiple directories',
@@ -34,7 +40,8 @@ const start = () =>
   apiDocMock({
     port: (/^\d+$/g.test(port) && port) || undefined,
     dataPath: watch,
-    docsPath: docs
+    docsPath: docs,
+    silent
   });
 
 if (process.env.NODE_ENV === 'test') {

--- a/src/index.js
+++ b/src/index.js
@@ -12,9 +12,10 @@ const cache = { app: null, httpTerminator: null };
  *
  * @param {(string|string[])} dataPath
  * @param {string} docsPath
+ * @param {boolean} silent
  * @returns {{}|*}
  */
-const setupDocs = (dataPath = '', docsPath = '') => {
+const setupDocs = (dataPath = '', docsPath = '', silent) => {
   const cwd = process.cwd();
   const dest = (docsPath && path.join(cwd, docsPath)) || null;
 
@@ -33,7 +34,7 @@ const setupDocs = (dataPath = '', docsPath = '') => {
       apimock: path.join(__dirname, './docs/configDocs.js')
     },
     dryRun: process.env.NODE_ENV === 'test',
-    silent: process.env.NODE_ENV === 'test'
+    silent: process.env.NODE_ENV === 'test' || silent
   };
 
   const apiJson = buildDocs({ apiDocsConfig });
@@ -75,10 +76,11 @@ const setupResponse = (apiJson = [], port) => {
  * @param {number} params.port
  * @param {(string|string[])} params.dataPath
  * @param {string} params.docsPath
+ * @param {boolean} params.silent
  * @returns {*}
  */
-const apiDocMock = async ({ port = 8000, dataPath, docsPath = '.docs' } = {}) => {
-  const apiJson = setupDocs(dataPath, docsPath);
+const apiDocMock = async ({ port = 8000, dataPath, docsPath = '.docs', silent } = {}) => {
+  const apiJson = setupDocs(dataPath, docsPath, silent);
   let httpTerminator = null;
 
   if (apiJson) {


### PR DESCRIPTION
## What's included
<!-- List your changes/additions, or commits -->
- feat(cli): expose apidoc option, silent

### Notes
- recent apiDoc package upgrade exposed a more verbose output if apiDoc doesn't like your "quickly documented" annotations, we default apiDoc to `silent` but expose the option in the event you want to be notified
<!-- Anything funky about your updates. Or issues that aren't resolved by this merge request, things of note? -->

## How to test
<!-- Are there directions to test/review? -->

### Coverage and basic unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test`
1. confirm tests come back clean
<!--
### Interactive unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test:dev`
-->


## Example
<!-- Append a demo/screenshot/animated gif, or a link to the aforementioned, of the cli output -->
...

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
ongoing