### PR TITLE
fix(buildApiResponse): response content type

### DIFF
--- a/src/__tests__/__snapshots__/buildApiResponse.test.js.snap
+++ b/src/__tests__/__snapshots__/buildApiResponse.test.js.snap
@@ -24,7 +24,7 @@ exports[`buildApiResponse should build a response with specific properties: buil
   ],
   [
     "Content-Type",
-    "text/plain",
+    "application/json",
   ],
 ]
 `;
@@ -94,7 +94,10 @@ exports[`buildApiResponse should parse random mock api settings: parseCustomMock
 
 exports[`buildApiResponse should return a mock mime type and parsed content: parseContentAndType 1`] = `
 {
-  "content": ""{\\n  \\"foo\\": \\"hello\\",\\n  \\"bar\\": \\"world\\"\\n}"",
+  "content": "{
+  "foo": "hello",
+  "bar": "world"
+}",
   "contentType": "application/json",
 }
 `;

--- a/src/__tests__/buildApiResponse.test.js
+++ b/src/__tests__/buildApiResponse.test.js
@@ -31,7 +31,25 @@ describe('buildApiResponse', () => {
     const mockApiResponse = [
       {
         type: 'get',
-        url: '/hello/world/'
+        url: '/hello/world/',
+        success: {
+          examples: [
+            {
+              title: 'Success-Response:',
+              content: 'HTTP/1.1 200 OK\n{\n  "foo": "hello",\n  "bar": "world"\n}',
+              type: 'json'
+            }
+          ]
+        },
+        error: {
+          examples: [
+            {
+              title: 'Error-Response:',
+              content: 'HTTP/1.1 400 Bad Request\n{\n  "detail": "Bad request."\n}',
+              type: 'json'
+            }
+          ]
+        }
       }
     ];
 
@@ -58,15 +76,15 @@ describe('buildApiResponse', () => {
     const objContent = 'HTTP/1.1 200 OK\n{\n  "foo": "hello",\n  "bar": "world"\n}';
     const contentType = 'json';
 
-    expect(getContentAndType({ content: objContent, contentType })).toMatchSnapshot('parseContentAndType');
+    expect(getContentAndType({ content: objContent, type: contentType })).toMatchSnapshot('parseContentAndType');
     expect(getContentAndType({ content: objContent })).toMatchSnapshot('parseContentAndType.fallback');
-    expect(getContentAndType({ content: objContent, contentType: 'lorem/ipsum' })).toMatchSnapshot(
+    expect(getContentAndType({ content: objContent, type: 'lorem/ipsum' })).toMatchSnapshot(
       'parseContentAndType.passthrough'
     );
 
     const xmlContent = `<lorem><ipsum dolor="sit" /></lorem>`;
-    expect(getContentAndType({ content: xmlContent, contentType: 'xml' })).toMatchSnapshot('parseContentAndType.xml');
-    expect(getContentAndType({ content: xmlContent, contentType: 'svg' })).toMatchSnapshot('parseContentAndType.svg');
+    expect(getContentAndType({ content: xmlContent, type: 'xml' })).toMatchSnapshot('parseContentAndType.xml');
+    expect(getContentAndType({ content: xmlContent, type: 'svg' })).toMatchSnapshot('parseContentAndType.svg');
   });
 
   it('should parse custom mock api settings', () => {

--- a/src/buildApiResponse.js
+++ b/src/buildApiResponse.js
@@ -68,10 +68,10 @@ const getCustomMockSettings = memo(({ settings = [] } = {}) => {
  *
  * @param {object} params
  * @param {string} params.content
- * @param {string} params.contentType
+ * @param {string} params.type
  * @returns {{content: string, contentType: string}}
  */
-const getContentAndType = memo(({ content = '', contentType = 'text' } = {}) => {
+const getContentAndType = memo(({ content = '', type: contentType } = {}) => {
   let updatedContent = content;
   let updatedType;
 
@@ -79,14 +79,10 @@ const getContentAndType = memo(({ content = '', contentType = 'text' } = {}) => 
     updatedContent = content.split(/\n/).slice(1).join('\n');
   }
 
-  if (new RegExp('json', 'i').test(contentType)) {
-    updatedContent = JSON.stringify(updatedContent, null, 2);
-  }
-
   /**
    * Ignore content types that already contain a `/`
    */
-  if (contentType.split('/').length > 1) {
+  if (contentType?.split('/').length > 1) {
     return {
       content: updatedContent,
       contentType
@@ -94,17 +90,21 @@ const getContentAndType = memo(({ content = '', contentType = 'text' } = {}) => 
   }
 
   switch (contentType) {
+    case 'zip':
+    case 'gzip':
     case 'json':
-      updatedType = 'application/json';
+      updatedType = `application/${contentType}`;
       break;
     case 'xml':
     case 'html':
     case 'csv':
+    case 'css':
       updatedType = `text/${contentType}`;
       break;
     case 'svg':
       updatedType = 'image/svg+xml';
       break;
+    case 'txt':
     default:
       updatedType = 'text/plain';
       break;


### PR DESCRIPTION
## What's included
<!-- List your changes/additions, or commits -->
* fix(buildApiResponse): response content type

### Notes
- patches a bug from the past year where every response returned is `text/plain` content type. It appears the issue was around commit 7fc30f9650123c853844b63adbf163c130651d3f and introduced in `v4.3.0`
   - ~unfortunately the unit tests wouldn't catch a simple parameter rename issue but an end-2-end would, we're reviewing how we can catch this in the future...~ mistaken, a consuming function unit test `buildResponse` helps cover this gap, test added
<!-- Anything funky about your updates. Or issues that aren't resolved by this merge request, things of note? -->

## How to test
<!-- Are there directions to test/review? -->

### Coverage and basic unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test`
1. confirm tests come back clean
<!--
### Interactive unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test:dev`
-->
### Local development run
1. update the NPM packages with `$ yarn`
1. `$ yarn start:dev`
1. modify example content types under the `./data/example.js` file to include
   - zip
   - gzip
   - css
   ... and confirm that is the response type returned in the `log` and `browser`

## Example
<!-- Append a demo/screenshot/animated gif, or a link to the aforementioned, of the cli output -->
...

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
ongoing