### PR TITLE
build(nodejs)!: remove 16 support

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [16.x, 18.x, 20.x]
+        node-version: [18.x, 20.x, 22.x]
     steps:
       - uses: actions/checkout@v4
       - name: Setup Node.js ${{ matrix.node-version }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18-alpine
+FROM node:20-alpine
 
 WORKDIR /app
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ a delay to see how your codebase will handle loading scenarios with a balls slow
 
 ## Requirements
 The basic requirements:
- * [NodeJS version 16+](https://nodejs.org/)
+ * [NodeJS version 18+](https://nodejs.org/)
  * Optionally your system could be running
     - [Docker](https://docs.docker.com/engine/installation/)
     - [podman](https://github.com/containers/podman) or [podman desktop](https://podman-desktop.io/)

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "server"
   ],
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=18.0.0"
   },
   "files": [
     "data/*",


### PR DESCRIPTION
## What's included
<!-- List your changes/additions, or commits -->
- build(nodejs)!: remove 16 support

### Notes
- removes support for nodejs 16 with upcoming release, breaking change. minimum package version that can be used with nodejs 16 is v4.7.0
<!-- Anything funky about your updates. Or issues that aren't resolved by this merge request, things of note? -->

## How to test
<!-- Are there directions to test/review? -->

### Coverage and basic unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm test`
1. confirm tests come back clean
   - confirm integration action covers nodejs 22 and applies 18 as min
<!--
### Interactive unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm run test:dev`
-->

## Example
<!-- Append a demo/screenshot/animated gif, or a link to the aforementioned, of the cli output -->
...

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
ongoing