### PR TITLE
build(deps): bump group with 5 updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "express": "^4.19.2",
         "http-terminator": "^3.2.0",
         "node-watch": "^0.7.4",
-        "winston": "^3.13.1",
+        "winston": "^3.14.2",
         "yargs": "^17.7.2"
       },
       "bin": {
@@ -21,18 +21,18 @@
       },
       "devDependencies": {
         "changelog-light": "^2.0.1",
-        "cspell": "^8.13.1",
+        "cspell": "^8.14.2",
         "eslint": "^8.57.0",
         "eslint-config-prettier": "^9.1.0",
         "eslint-plugin-babel": "^5.3.1",
         "eslint-plugin-import": "^2.29.1",
-        "eslint-plugin-jest": "^28.7.0",
-        "eslint-plugin-jsdoc": "^48.11.0",
+        "eslint-plugin-jest": "^28.8.0",
+        "eslint-plugin-jsdoc": "^50.2.2",
         "eslint-plugin-node": "^11.1.0",
         "eslint-plugin-prettier": "^5.2.1",
         "jest": "^29.7.0",
         "nodemon": "^3.1.4",
-        "npm-check-updates": "^17.0.3",
+        "npm-check-updates": "^17.1.0",
         "npm-run-all": "^4.1.5",
         "prettier": "^3.3.3"
       },
@@ -610,27 +610,27 @@
       "dev": true
     },
     "node_modules/@cspell/cspell-bundled-dicts": {
-      "version": "8.13.1",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-bundled-dicts/-/cspell-bundled-dicts-8.13.1.tgz",
-      "integrity": "sha512-ylAwnIdxBMJ9v6BHpFAQFZM+5zbybLtqVQJG7zQePts4e0/Qr2xjYFbC3F+fovZqyXPIx24BR+S6gFJNO1OdAw==",
+      "version": "8.14.2",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-bundled-dicts/-/cspell-bundled-dicts-8.14.2.tgz",
+      "integrity": "sha512-Kv2Utj/RTSxfufGXkkoTZ/3ErCsYWpCijtDFr/FwSsM7mC0PzLpdlcD9xjtgrJO5Kwp7T47iTG21U4Mwddyi8Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@cspell/dict-ada": "^4.0.2",
         "@cspell/dict-aws": "^4.0.3",
         "@cspell/dict-bash": "^4.1.3",
-        "@cspell/dict-companies": "^3.1.3",
+        "@cspell/dict-companies": "^3.1.4",
         "@cspell/dict-cpp": "^5.1.12",
         "@cspell/dict-cryptocurrencies": "^5.0.0",
         "@cspell/dict-csharp": "^4.0.2",
-        "@cspell/dict-css": "^4.0.12",
+        "@cspell/dict-css": "^4.0.13",
         "@cspell/dict-dart": "^2.0.3",
         "@cspell/dict-django": "^4.1.0",
         "@cspell/dict-docker": "^1.1.7",
         "@cspell/dict-dotnet": "^5.0.2",
         "@cspell/dict-elixir": "^4.0.3",
         "@cspell/dict-en_us": "^4.3.23",
-        "@cspell/dict-en-common-misspellings": "^2.0.3",
+        "@cspell/dict-en-common-misspellings": "^2.0.4",
         "@cspell/dict-en-gb": "1.1.33",
         "@cspell/dict-filetypes": "^3.0.4",
         "@cspell/dict-fonts": "^4.0.0",
@@ -656,13 +656,13 @@
         "@cspell/dict-php": "^4.0.8",
         "@cspell/dict-powershell": "^5.0.5",
         "@cspell/dict-public-licenses": "^2.0.7",
-        "@cspell/dict-python": "^4.2.3",
+        "@cspell/dict-python": "^4.2.4",
         "@cspell/dict-r": "^2.0.1",
         "@cspell/dict-ruby": "^5.0.2",
         "@cspell/dict-rust": "^4.0.5",
         "@cspell/dict-scala": "^5.0.3",
-        "@cspell/dict-software-terms": "^4.0.3",
-        "@cspell/dict-sql": "^2.1.3",
+        "@cspell/dict-software-terms": "^4.0.6",
+        "@cspell/dict-sql": "^2.1.5",
         "@cspell/dict-svelte": "^1.0.2",
         "@cspell/dict-swift": "^2.0.1",
         "@cspell/dict-terraform": "^1.0.0",
@@ -674,22 +674,22 @@
       }
     },
     "node_modules/@cspell/cspell-json-reporter": {
-      "version": "8.13.1",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-json-reporter/-/cspell-json-reporter-8.13.1.tgz",
-      "integrity": "sha512-vYZTBRkYjpNBifGNbYQsgIXesDEdUa9QAwllDcLZGKbhh5mY/C1ygPnAVpYDYiJNt1WCeIqW286DUyjRjkmHeA==",
+      "version": "8.14.2",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-json-reporter/-/cspell-json-reporter-8.14.2.tgz",
+      "integrity": "sha512-TZavcnNIZKX1xC/GNj80RgFVKHCT4pHT0qm9jCsQFH2QJfyCrUlkEvotKGSQ04lAyCwWg6Enq95qhouF8YbKUQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@cspell/cspell-types": "8.13.1"
+        "@cspell/cspell-types": "8.14.2"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@cspell/cspell-pipe": {
-      "version": "8.13.1",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-pipe/-/cspell-pipe-8.13.1.tgz",
-      "integrity": "sha512-acLWTQv3yWfeWXMds/cfQKZapslOrLHVL4VDp4rFyL/EnfgaCr7Ew9hQ7zAIARY3r/n0dByqWbOt2HKthdhx/g==",
+      "version": "8.14.2",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-pipe/-/cspell-pipe-8.14.2.tgz",
+      "integrity": "sha512-aWMoXZAXEre0/M9AYWOW33YyOJZ06i4vvsEpWBDWpHpWQEmsR/7cMMgld8Pp3wlEjIUclUAKTYmrZ61PFWU/og==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -697,9 +697,9 @@
       }
     },
     "node_modules/@cspell/cspell-resolver": {
-      "version": "8.13.1",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-resolver/-/cspell-resolver-8.13.1.tgz",
-      "integrity": "sha512-EGdb7KLYCklV3sLxf/895b7s6sExh8DCHZFpDos2hjKwMt+F4ynsu1+ceybQtqoUF/MsyLoJXrrmPvV2uGVmUQ==",
+      "version": "8.14.2",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-resolver/-/cspell-resolver-8.14.2.tgz",
+      "integrity": "sha512-pSyBsAvslaN0dx0pHdvECJEuFDDBJGAD6G8U4BVbIyj2OPk0Ox0HrZIj6csYxxoJERAgNO/q7yCPwa4j9NNFXg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -710,9 +710,9 @@
       }
     },
     "node_modules/@cspell/cspell-service-bus": {
-      "version": "8.13.1",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-service-bus/-/cspell-service-bus-8.13.1.tgz",
-      "integrity": "sha512-oLFJfxuB1rwGXn3eD5qSF9nf0lHu6YjO0JcrjWhAZQ0r3AsO97gsX50wwCFCw6szVU3rd1cTUktW0KYEZUY6dA==",
+      "version": "8.14.2",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-service-bus/-/cspell-service-bus-8.14.2.tgz",
+      "integrity": "sha512-WUF7xf3YgXYIqjmBwLcVugYIrYL4WfXchgSo9rmbbnOcAArzsK+HKfzb4AniZAJ1unxcIQ0JnVlRmnCAKPjjLg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -720,9 +720,9 @@
       }
     },
     "node_modules/@cspell/cspell-types": {
-      "version": "8.13.1",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-types/-/cspell-types-8.13.1.tgz",
-      "integrity": "sha512-9dJdmyXLXJVesCJa/DWgwKsEC9p2RRFc6KORcLhNvtm1tE9TvCXiu5jV47sOmYXd6Hwan8IurBXXTz82CLVjPQ==",
+      "version": "8.14.2",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-types/-/cspell-types-8.14.2.tgz",
+      "integrity": "sha512-MRY8MjBNOKGMDSkxAKueYAgVL43miO+lDcLCBBP+7cNXqHiUFMIZteONcGp3kJT0dWS04dN6lKAXvaNF0aWcng==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -737,16 +737,16 @@
       "license": "MIT"
     },
     "node_modules/@cspell/dict-aws": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-aws/-/dict-aws-4.0.3.tgz",
-      "integrity": "sha512-0C0RQ4EM29fH0tIYv+EgDQEum0QI6OrmjENC9u98pB8UcnYxGG/SqinuPxo+TgcEuInj0Q73MsBpJ1l5xUnrsw==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-aws/-/dict-aws-4.0.4.tgz",
+      "integrity": "sha512-6AWI/Kkf+RcX/J81VX8+GKLeTgHWEr/OMhGk3dHQzWK66RaqDJCGDqi7494ghZKcBB7dGa3U5jcKw2FZHL/u3w==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@cspell/dict-bash": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-bash/-/dict-bash-4.1.3.tgz",
-      "integrity": "sha512-tOdI3QVJDbQSwPjUkOiQFhYcu2eedmX/PtEpVWg0aFps/r6AyjUQINtTgpqMYnYuq8O1QUIQqnpx21aovcgZCw==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-bash/-/dict-bash-4.1.4.tgz",
+      "integrity": "sha512-W/AHoQcJYn3Vn/tUiXX2+6D/bhfzdDshwcbQWv9TdiNlXP9P6UJjDKWbxyA5ogJCsR2D0X9Kx11oV8E58siGKQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -758,9 +758,9 @@
       "license": "MIT"
     },
     "node_modules/@cspell/dict-cpp": {
-      "version": "5.1.12",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-cpp/-/dict-cpp-5.1.12.tgz",
-      "integrity": "sha512-6lXLOFIa+k/qBcu0bjaE/Kc6v3sh9VhsDOXD1Dalm3zgd0QIMjp5XBmkpSdCAK3pWCPV0Se7ysVLDfCea1BuXg==",
+      "version": "5.1.16",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-cpp/-/dict-cpp-5.1.16.tgz",
+      "integrity": "sha512-32fU5RkuOM55IRcxjByiSoKbjr+C4danDfYjHaQNRWdvjzJzci3fLDGA2wTXiclkgDODxGiV8LCTUwCz+3TNWA==",
       "dev": true,
       "license": "MIT"
     },
@@ -779,9 +779,9 @@
       "license": "MIT"
     },
     "node_modules/@cspell/dict-css": {
-      "version": "4.0.12",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-css/-/dict-css-4.0.12.tgz",
-      "integrity": "sha512-vGBgPM92MkHQF5/2jsWcnaahOZ+C6OE/fPvd5ScBP72oFY9tn5GLuomcyO0z8vWCr2e0nUSX1OGimPtcQAlvSw==",
+      "version": "4.0.13",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-css/-/dict-css-4.0.13.tgz",
+      "integrity": "sha512-WfOQkqlAJTo8eIQeztaH0N0P+iF5hsJVKFuhy4jmARPISy8Efcv8QXk2/IVbmjJH0/ZV7dKRdnY5JFVXuVz37g==",
       "dev": true,
       "license": "MIT"
     },
@@ -814,9 +814,9 @@
       "license": "MIT"
     },
     "node_modules/@cspell/dict-dotnet": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-dotnet/-/dict-dotnet-5.0.2.tgz",
-      "integrity": "sha512-UD/pO2A2zia/YZJ8Kck/F6YyDSpCMq0YvItpd4YbtDVzPREfTZ48FjZsbYi4Jhzwfvc6o8R56JusAE58P+4sNQ==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-dotnet/-/dict-dotnet-5.0.5.tgz",
+      "integrity": "sha512-gjg0L97ee146wX47dnA698cHm85e7EOpf9mVrJD8DmEaqoo/k1oPy2g7c7LgKxK9XnqwoXxhLNnngPrwXOoEtQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -891,9 +891,9 @@
       "license": "MIT"
     },
     "node_modules/@cspell/dict-golang": {
-      "version": "6.0.9",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-golang/-/dict-golang-6.0.9.tgz",
-      "integrity": "sha512-etDt2WQauyEQDA+qPS5QtkYTb2I9l5IfQftAllVoB1aOrT6bxxpHvMEpJ0Hsn/vezxrCqa/BmtUbRxllIxIuSg==",
+      "version": "6.0.12",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-golang/-/dict-golang-6.0.12.tgz",
+      "integrity": "sha512-LEPeoqd+4O+vceHF73S7D7+LYfrAjOvp4Dqzh4MT30ruzlQ77yHRSuYOJtrFN1GK5ntAt/ILSVOKg9sgsz1Llg==",
       "dev": true,
       "license": "MIT"
     },
@@ -989,37 +989,37 @@
       "license": "MIT"
     },
     "node_modules/@cspell/dict-npm": {
-      "version": "5.0.18",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-npm/-/dict-npm-5.0.18.tgz",
-      "integrity": "sha512-weMTyxWpzz19q4wv9n183BtFvdD5fCjtze+bFKpl+4rO/YlPhHL2cXLAeexJz/VDSBecwX4ybTZYoknd1h2J4w==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-npm/-/dict-npm-5.1.1.tgz",
+      "integrity": "sha512-yMAttAXvxtfjg1Oy7Jyq1wqjL3sz41ZP6m2HtvorDZyABk+4hKh8knK1sSZCTcuHpVoWr7yGRGJyAj3anEOxuQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@cspell/dict-php": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-php/-/dict-php-4.0.8.tgz",
-      "integrity": "sha512-TBw3won4MCBQ2wdu7kvgOCR3dY2Tb+LJHgDUpuquy3WnzGiSDJ4AVelrZdE1xu7mjFJUr4q48aB21YT5uQqPZA==",
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-php/-/dict-php-4.0.10.tgz",
+      "integrity": "sha512-NfTZdp6kcZDF1PvgQ6cY0zE4FUO5rSwNmBH/iwCBuaLfJAFQ97rgjxo+D2bic4CFwNjyHutnHPtjJBRANO5XQw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@cspell/dict-powershell": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-powershell/-/dict-powershell-5.0.5.tgz",
-      "integrity": "sha512-3JVyvMoDJesAATYGOxcUWPbQPUvpZmkinV3m8HL1w1RrjeMVXXuK7U1jhopSneBtLhkU+9HKFwgh9l9xL9mY2Q==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-powershell/-/dict-powershell-5.0.6.tgz",
+      "integrity": "sha512-BSi9tmnT7jgNsH5SaHSg70aw+4YwTjkkZBfhHtin0r6AMV2RaiLzsBPvzZGXOcm0yTvl975HYoKMqflXIlk2RA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@cspell/dict-public-licenses": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-public-licenses/-/dict-public-licenses-2.0.7.tgz",
-      "integrity": "sha512-KlBXuGcN3LE7tQi/GEqKiDewWGGuopiAD0zRK1QilOx5Co8XAvs044gk4MNIQftc8r0nHeUI+irJKLGcR36DIQ==",
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-public-licenses/-/dict-public-licenses-2.0.8.tgz",
+      "integrity": "sha512-Sup+tFS7cDV0fgpoKtUqEZ6+fA/H+XUgBiqQ/Fbs6vUE3WCjJHOIVsP+udHuyMH7iBfJ4UFYOYeORcY4EaKdMg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@cspell/dict-python": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-python/-/dict-python-4.2.4.tgz",
-      "integrity": "sha512-sCtLBqMreb+8zRW2bXvFsfSnRUVU6IFm4mT6Dc4xbz0YajprbaPPh/kOUTw5IJRP8Uh+FFb7Xp2iH03CNWRq/A==",
+      "version": "4.2.6",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-python/-/dict-python-4.2.6.tgz",
+      "integrity": "sha512-Hkz399qDGEbfXi9GYa2hDl7GahglI86JmS2F1KP8sfjLXofUgtnknyC5NWc86nzHcP38pZiPqPbTigyDYw5y8A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1034,9 +1034,9 @@
       "license": "MIT"
     },
     "node_modules/@cspell/dict-ruby": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-ruby/-/dict-ruby-5.0.2.tgz",
-      "integrity": "sha512-cIh8KTjpldzFzKGgrqUX4bFyav5lC52hXDKo4LbRuMVncs3zg4hcSf4HtURY+f2AfEZzN6ZKzXafQpThq3dl2g==",
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-ruby/-/dict-ruby-5.0.3.tgz",
+      "integrity": "sha512-V1xzv9hN6u8r6SM4CkYdsxs4ov8gjXXo0Twfx5kWhLXbEVxTXDMt7ohLTqpy2XlF5mutixZdbHMeFiAww8v+Ug==",
       "dev": true,
       "license": "MIT"
     },
@@ -1055,9 +1055,9 @@
       "license": "MIT"
     },
     "node_modules/@cspell/dict-software-terms": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-software-terms/-/dict-software-terms-4.0.5.tgz",
-      "integrity": "sha512-93knOtaQlWq1Zlz5LbjOl3P3hIiWbhd7kwGZPHVxCdD8+G3UEF9hivkpZ1miK/DzlV/Lcw2RoybOd91Xazc+dg==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-software-terms/-/dict-software-terms-4.1.2.tgz",
+      "integrity": "sha512-+l9E1HaIGHYBm2zooYJa6f+ybw+pUOPM6Md6sH8eoi+Lhyd5Pi0e7HWAYKfgSMz+EK8ObkqKjblu6vuuMllQnA==",
       "dev": true,
       "license": "MIT"
     },
@@ -1083,9 +1083,9 @@
       "license": "MIT"
     },
     "node_modules/@cspell/dict-terraform": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-terraform/-/dict-terraform-1.0.0.tgz",
-      "integrity": "sha512-Ak+vy4HP/bOgzf06BAMC30+ZvL9mzv21xLM2XtfnBLTDJGdxlk/nK0U6QT8VfFLqJ0ZZSpyOxGsUebWDCTr/zQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-terraform/-/dict-terraform-1.0.1.tgz",
+      "integrity": "sha512-29lmUUnZgPh+ieZ5hunick8hzNIpNRtiJh9vAusNskPCrig3RTW6u7F+GG1a8uyslbzSw+Irjf40PTOan1OJJA==",
       "dev": true,
       "license": "MIT"
     },
@@ -1104,9 +1104,9 @@
       "license": "MIT"
     },
     "node_modules/@cspell/dynamic-import": {
-      "version": "8.13.1",
-      "resolved": "https://registry.npmjs.org/@cspell/dynamic-import/-/dynamic-import-8.13.1.tgz",
-      "integrity": "sha512-jMqJHWmQy+in99JMSFlaGV9P033gCx7DCZvGO/ZSeZ2EatrUTanJk3oTG1TZknZydb0nnxr1mgTWXN7PCAAXDg==",
+      "version": "8.14.2",
+      "resolved": "https://registry.npmjs.org/@cspell/dynamic-import/-/dynamic-import-8.14.2.tgz",
+      "integrity": "sha512-5MbqtIligU7yPwHWU/5yFCgMvur4i1bRAF1Cy8y2dDtHsa204S/w/SaXs+51EFLp2eNbCiBisCBrwJFT7R1RxA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1116,10 +1116,20 @@
         "node": ">=18.0"
       }
     },
+    "node_modules/@cspell/filetypes": {
+      "version": "8.14.2",
+      "resolved": "https://registry.npmjs.org/@cspell/filetypes/-/filetypes-8.14.2.tgz",
+      "integrity": "sha512-ZevArA0mWeVTTqHicxCPZIAeCibpY3NwWK/x6d1Lgu7RPk/daoGAM546Q2SLChFu+r10tIH7pRG212A6Q9ihPA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@cspell/strong-weak-map": {
-      "version": "8.13.1",
-      "resolved": "https://registry.npmjs.org/@cspell/strong-weak-map/-/strong-weak-map-8.13.1.tgz",
-      "integrity": "sha512-ga1ibI9ZLJWNszfP7e6qQ8gnoQOP9rE/clALMAim9ssO6cmMhEEm+i1ROH4nsDfThd6sVlUJ0IOtx5dEqPmWxw==",
+      "version": "8.14.2",
+      "resolved": "https://registry.npmjs.org/@cspell/strong-weak-map/-/strong-weak-map-8.14.2.tgz",
+      "integrity": "sha512-7sRzJc392CQYNNrtdPEfOHJdRqsqf6nASCtbS5A9hL2UrdWQ4uN7r/D+Y1HpuizwY9eOkZvarcFfsYt5wE0Pug==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1127,9 +1137,9 @@
       }
     },
     "node_modules/@cspell/url": {
-      "version": "8.13.1",
-      "resolved": "https://registry.npmjs.org/@cspell/url/-/url-8.13.1.tgz",
-      "integrity": "sha512-cCyojz5ovgGCexhez2urle4Q1UOEsp96lvl4pDmWNDHa/6n8dqiIn60SVzQIsAHzJ4yEV077RSaIrTlq/T+oSQ==",
+      "version": "8.14.2",
+      "resolved": "https://registry.npmjs.org/@cspell/url/-/url-8.14.2.tgz",
+      "integrity": "sha512-YmWW+B/2XQcCynLpiAQF77Bitm5Cynw3/BICZkbdveKjJkUzEmXB+U2qWuwXOyU8xUYuwkP63YM8McnI567rUA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1155,14 +1165,15 @@
       }
     },
     "node_modules/@es-joy/jsdoccomment": {
-      "version": "0.46.0",
-      "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.46.0.tgz",
-      "integrity": "sha512-C3Axuq1xd/9VqFZpW4YAzOx5O9q/LP46uIQy/iNDpHG3fmPa6TBtvfglMCs3RBiBxAIi0Go97r8+jvTt55XMyQ==",
+      "version": "0.48.0",
+      "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.48.0.tgz",
+      "integrity": "sha512-G6QUWIcC+KvSwXNsJyDTHvqUdNoAVJPPgkc3+Uk4WBKqZvoXhlvazOgm9aL0HwihJLQf0l+tOE2UFzXBqCqgDw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "comment-parser": "1.4.1",
         "esquery": "^1.6.0",
-        "jsdoc-type-pratt-parser": "~4.0.0"
+        "jsdoc-type-pratt-parser": "~4.1.0"
       },
       "engines": {
         "node": ">=16"
@@ -3832,9 +3843,9 @@
       }
     },
     "node_modules/comment-json": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/comment-json/-/comment-json-4.2.4.tgz",
-      "integrity": "sha512-E5AjpSW+O+N5T2GsOQMHLLsJvrYw6G/AFt9GvU6NguEAfzKShh7hRiLtVo6S9KbRpFMGqE5ojo0/hE+sdteWvQ==",
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/comment-json/-/comment-json-4.2.5.tgz",
+      "integrity": "sha512-bKw/r35jR3HGt5PEPm1ljsQQGyCrR8sFGNiN5L+ykDHdpO8Smxkrkla9Yi6NkQyUrb8V54PGhfMs6NrIwtxtdw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3853,6 +3864,7 @@
       "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.4.1.tgz",
       "integrity": "sha512-buhp5kePrmda3vhc5B9t7pUQXAb2Tnd0qgpkIhPhkHXxJpiPJ11H0ZEU0oBpJ2QztSbzG/ZxMj/CHsYJqRHmyg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 12.0.0"
       }
@@ -3997,25 +4009,25 @@
       }
     },
     "node_modules/cspell": {
-      "version": "8.13.1",
-      "resolved": "https://registry.npmjs.org/cspell/-/cspell-8.13.1.tgz",
-      "integrity": "sha512-Bqppilpwx9xt3jZPaYcqe1JPteNmfKhx9pw9YglZEePDUzdiJQNVIfs31589GAnXjgdqqctR8N87ffLcaBNPXw==",
+      "version": "8.14.2",
+      "resolved": "https://registry.npmjs.org/cspell/-/cspell-8.14.2.tgz",
+      "integrity": "sha512-ii/W7fwO4chNQVYl1C/8k7RW8EXzLb69rvg08p8mSJx8B2UasVJ9tuJpTH2Spo1jX6N3H0dKPWUbd1fAmdAhPg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@cspell/cspell-json-reporter": "8.13.1",
-        "@cspell/cspell-pipe": "8.13.1",
-        "@cspell/cspell-types": "8.13.1",
-        "@cspell/dynamic-import": "8.13.1",
-        "@cspell/url": "8.13.1",
+        "@cspell/cspell-json-reporter": "8.14.2",
+        "@cspell/cspell-pipe": "8.14.2",
+        "@cspell/cspell-types": "8.14.2",
+        "@cspell/dynamic-import": "8.14.2",
+        "@cspell/url": "8.14.2",
         "chalk": "^5.3.0",
         "chalk-template": "^1.1.0",
         "commander": "^12.1.0",
-        "cspell-dictionary": "8.13.1",
-        "cspell-gitignore": "8.13.1",
-        "cspell-glob": "8.13.1",
-        "cspell-io": "8.13.1",
-        "cspell-lib": "8.13.1",
+        "cspell-dictionary": "8.14.2",
+        "cspell-gitignore": "8.14.2",
+        "cspell-glob": "8.14.2",
+        "cspell-io": "8.14.2",
+        "cspell-lib": "8.14.2",
         "fast-glob": "^3.3.2",
         "fast-json-stable-stringify": "^2.1.0",
         "file-entry-cache": "^9.0.0",
@@ -4035,14 +4047,14 @@
       }
     },
     "node_modules/cspell-config-lib": {
-      "version": "8.13.1",
-      "resolved": "https://registry.npmjs.org/cspell-config-lib/-/cspell-config-lib-8.13.1.tgz",
-      "integrity": "sha512-sXUFOyxvk+qDkoQdFkVEqj1hfQWzMi+tbi6ksiotQaqpm7r+YitZLSgwJjN4xgDO/rTLyP70k9fagdZ67MVZbw==",
+      "version": "8.14.2",
+      "resolved": "https://registry.npmjs.org/cspell-config-lib/-/cspell-config-lib-8.14.2.tgz",
+      "integrity": "sha512-yHP1BdcH5dbjb8qiZr6+bxEnJ+rxTULQ00wBz3eBPWCghJywEAYYvMWoYuxVtPpndlkKYC1wJAHsyNkweQyepA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@cspell/cspell-types": "8.13.1",
-        "comment-json": "^4.2.4",
+        "@cspell/cspell-types": "8.14.2",
+        "comment-json": "^4.2.5",
         "yaml": "^2.5.0"
       },
       "engines": {
@@ -4050,15 +4062,15 @@
       }
     },
     "node_modules/cspell-dictionary": {
-      "version": "8.13.1",
-      "resolved": "https://registry.npmjs.org/cspell-dictionary/-/cspell-dictionary-8.13.1.tgz",
-      "integrity": "sha512-Z0T4J4ahOJaHmWq83w24KXGik1zeauO5WvDRyzDyaSgpbA5MN2hN98LvxaIx72g3I+trtRK77XFcKginuME9EA==",
+      "version": "8.14.2",
+      "resolved": "https://registry.npmjs.org/cspell-dictionary/-/cspell-dictionary-8.14.2.tgz",
+      "integrity": "sha512-gWuAvf6queGGUvGbfAxxUq55cZ0OevWPbjnCrSB0PpJ4tqdFd8dLcvVrIKzoE2sBXKPw2NDkmoEngs6iGavC0w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@cspell/cspell-pipe": "8.13.1",
-        "@cspell/cspell-types": "8.13.1",
-        "cspell-trie-lib": "8.13.1",
+        "@cspell/cspell-pipe": "8.14.2",
+        "@cspell/cspell-types": "8.14.2",
+        "cspell-trie-lib": "8.14.2",
         "fast-equals": "^5.0.1"
       },
       "engines": {
@@ -4066,15 +4078,15 @@
       }
     },
     "node_modules/cspell-gitignore": {
-      "version": "8.13.1",
-      "resolved": "https://registry.npmjs.org/cspell-gitignore/-/cspell-gitignore-8.13.1.tgz",
-      "integrity": "sha512-XyZ3X5d6x0gkWtNXSAQRcPMG41bEdLx9cTgZCYCJhEZCesU1VpNm60F3oc11dMLkO+BqPH3An+AO/YEIiaje3A==",
+      "version": "8.14.2",
+      "resolved": "https://registry.npmjs.org/cspell-gitignore/-/cspell-gitignore-8.14.2.tgz",
+      "integrity": "sha512-lrO/49NaKBpkR7vFxv4OOY+oHmsG5+gNQejrBBWD9Nv9vvjJtz/G36X/rcN6M6tFcQQMWwa01kf04nxz8Ejuhg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@cspell/url": "8.13.1",
-        "cspell-glob": "8.13.1",
-        "cspell-io": "8.13.1",
+        "@cspell/url": "8.14.2",
+        "cspell-glob": "8.14.2",
+        "cspell-io": "8.14.2",
         "find-up-simple": "^1.0.0"
       },
       "bin": {
@@ -4085,13 +4097,13 @@
       }
     },
     "node_modules/cspell-glob": {
-      "version": "8.13.1",
-      "resolved": "https://registry.npmjs.org/cspell-glob/-/cspell-glob-8.13.1.tgz",
-      "integrity": "sha512-rW1A3t7YvPXxcC4z1pp1m9coeWzUVUmRjUw3vMNGlEDC2zecB39KKbEqesziBqnBceNAY7O5itllIGFKr03vqA==",
+      "version": "8.14.2",
+      "resolved": "https://registry.npmjs.org/cspell-glob/-/cspell-glob-8.14.2.tgz",
+      "integrity": "sha512-9Q1Kgoo1ev3fKTpp9y5n8M4RLxd8B0f5o4y5FQe4dBU0j/bt+/YDrLZNWDm77JViV606XQ6fimG1FTTq6pT9/g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@cspell/url": "8.13.1",
+        "@cspell/url": "8.14.2",
         "micromatch": "^4.0.7"
       },
       "engines": {
@@ -4099,14 +4111,14 @@
       }
     },
     "node_modules/cspell-grammar": {
-      "version": "8.13.1",
-      "resolved": "https://registry.npmjs.org/cspell-grammar/-/cspell-grammar-8.13.1.tgz",
-      "integrity": "sha512-HUkd24bulvBwee1UNBurxGlPUOiywb9pB34iXXoxFWuloHohZ/DuFlE8B/31ZtjW48ffEYIu3QZfWhcnD8e81w==",
+      "version": "8.14.2",
+      "resolved": "https://registry.npmjs.org/cspell-grammar/-/cspell-grammar-8.14.2.tgz",
+      "integrity": "sha512-eYwceVP80FGYVJenE42ALnvEKOXaXjq4yVbb1Ni1umO/9qamLWNCQ1RP6rRACy5e/cXviAbhrQ5Mtw6n+pyPEQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@cspell/cspell-pipe": "8.13.1",
-        "@cspell/cspell-types": "8.13.1"
+        "@cspell/cspell-pipe": "8.14.2",
+        "@cspell/cspell-types": "8.14.2"
       },
       "bin": {
         "cspell-grammar": "bin.mjs"
@@ -4116,41 +4128,42 @@
       }
     },
     "node_modules/cspell-io": {
-      "version": "8.13.1",
-      "resolved": "https://registry.npmjs.org/cspell-io/-/cspell-io-8.13.1.tgz",
-      "integrity": "sha512-t2sgZuWGBzPSOAStfvz/U3KoFEfDxEt1cXZj0Kd0Vs36v2uoLktm6ihMe7XNFu7zIdOFSajsYQ8Bi4RSLPGPxQ==",
+      "version": "8.14.2",
+      "resolved": "https://registry.npmjs.org/cspell-io/-/cspell-io-8.14.2.tgz",
+      "integrity": "sha512-uaKpHiY3DAgfdzgKMQml6U8F8o9udMuYxGqYa5FVfN7D5Ap7B2edQzSLTUYwxrFEn4skSfp6XY73+nzJvxzH4Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@cspell/cspell-service-bus": "8.13.1",
-        "@cspell/url": "8.13.1"
+        "@cspell/cspell-service-bus": "8.14.2",
+        "@cspell/url": "8.14.2"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/cspell-lib": {
-      "version": "8.13.1",
-      "resolved": "https://registry.npmjs.org/cspell-lib/-/cspell-lib-8.13.1.tgz",
-      "integrity": "sha512-H1HHG1pmATSeAaY0KmQ0xnkbSqJLvh9QpXWARDLWKUBvtE+/l44H4yVhIp/No3rM7PKMmb82GuSJzMaoIhHFLQ==",
+      "version": "8.14.2",
+      "resolved": "https://registry.npmjs.org/cspell-lib/-/cspell-lib-8.14.2.tgz",
+      "integrity": "sha512-d2oiIXHXnADmnhIuFLOdNE63L7OUfzgpLbYaqAWbkImCUDkevfGrOgnX8TJ03fUgZID4nvQ+3kgu/n2j4eLZjQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@cspell/cspell-bundled-dicts": "8.13.1",
-        "@cspell/cspell-pipe": "8.13.1",
-        "@cspell/cspell-resolver": "8.13.1",
-        "@cspell/cspell-types": "8.13.1",
-        "@cspell/dynamic-import": "8.13.1",
-        "@cspell/strong-weak-map": "8.13.1",
-        "@cspell/url": "8.13.1",
+        "@cspell/cspell-bundled-dicts": "8.14.2",
+        "@cspell/cspell-pipe": "8.14.2",
+        "@cspell/cspell-resolver": "8.14.2",
+        "@cspell/cspell-types": "8.14.2",
+        "@cspell/dynamic-import": "8.14.2",
+        "@cspell/filetypes": "8.14.2",
+        "@cspell/strong-weak-map": "8.14.2",
+        "@cspell/url": "8.14.2",
         "clear-module": "^4.1.2",
-        "comment-json": "^4.2.4",
-        "cspell-config-lib": "8.13.1",
-        "cspell-dictionary": "8.13.1",
-        "cspell-glob": "8.13.1",
-        "cspell-grammar": "8.13.1",
-        "cspell-io": "8.13.1",
-        "cspell-trie-lib": "8.13.1",
+        "comment-json": "^4.2.5",
+        "cspell-config-lib": "8.14.2",
+        "cspell-dictionary": "8.14.2",
+        "cspell-glob": "8.14.2",
+        "cspell-grammar": "8.14.2",
+        "cspell-io": "8.14.2",
+        "cspell-trie-lib": "8.14.2",
         "env-paths": "^3.0.0",
         "fast-equals": "^5.0.1",
         "gensequence": "^7.0.0",
@@ -4165,14 +4178,14 @@
       }
     },
     "node_modules/cspell-trie-lib": {
-      "version": "8.13.1",
-      "resolved": "https://registry.npmjs.org/cspell-trie-lib/-/cspell-trie-lib-8.13.1.tgz",
-      "integrity": "sha512-2moCsIYDmMT7hp5Non3CvWatfXptFWCuxjbXQGDNvWJ2Cj3oso/oBe4802GJv5GEenv9QBWmEtum/E7rFcx4JA==",
+      "version": "8.14.2",
+      "resolved": "https://registry.npmjs.org/cspell-trie-lib/-/cspell-trie-lib-8.14.2.tgz",
+      "integrity": "sha512-rZMbaEBGoyy4/zxKECaMyVyGLbuUxYmZ5jlEgiA3xPtEdWwJ4iWRTo5G6dWbQsXoxPYdAXXZ0/q0GQ2y6Jt0kw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@cspell/cspell-pipe": "8.13.1",
-        "@cspell/cspell-types": "8.13.1",
+        "@cspell/cspell-pipe": "8.14.2",
+        "@cspell/cspell-types": "8.14.2",
         "gensequence": "^7.0.0"
       },
       "engines": {
@@ -4240,9 +4253,10 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.3.5",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.5.tgz",
-      "integrity": "sha512-pt0bNEmneDIvdL1Xsd9oDQ/wrQRkXDT4AUWlNZNPKvW5x/jyO9VFXkJUP07vQ2upmw5PlaITaPKc31jK13V+jg==",
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.6.tgz",
+      "integrity": "sha512-O/09Bd4Z1fBrU4VzkhFqVgpPzaGbw6Sm9FEkBT1A/YBXQFGuuSxa1dN2nxgxS34JmKXqYx8CZAwEVoJFImUXIg==",
+      "license": "MIT",
       "dependencies": {
         "ms": "2.1.2"
       },
@@ -4918,9 +4932,9 @@
       }
     },
     "node_modules/eslint-plugin-jest": {
-      "version": "28.7.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-28.7.0.tgz",
-      "integrity": "sha512-fzPGN7awL2ftVRQh/bsCi+16ArUZWujZnD1b8EGJqy8nr4//7tZ3BIdc/9edcJBtB3hpci3GtdMNFVDwHU0Eag==",
+      "version": "28.8.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-28.8.0.tgz",
+      "integrity": "sha512-Tubj1hooFxCl52G4qQu0edzV/+EZzPUeN8p2NnW5uu4fbDs+Yo7+qDVDc4/oG3FbCqEBmu/OC3LSsyiU22oghw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4944,16 +4958,16 @@
       }
     },
     "node_modules/eslint-plugin-jsdoc": {
-      "version": "48.11.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-48.11.0.tgz",
-      "integrity": "sha512-d12JHJDPNo7IFwTOAItCeJY1hcqoIxE0lHA8infQByLilQ9xkqrRa6laWCnsuCrf+8rUnvxXY1XuTbibRBNylA==",
+      "version": "50.2.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-50.2.2.tgz",
+      "integrity": "sha512-i0ZMWA199DG7sjxlzXn5AeYZxpRfMJjDPUl7lL9eJJX8TPRoIaxJU4ys/joP5faM5AXE1eqW/dslCj3uj4Nqpg==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@es-joy/jsdoccomment": "~0.46.0",
+        "@es-joy/jsdoccomment": "~0.48.0",
         "are-docs-informative": "^0.0.2",
         "comment-parser": "1.4.1",
-        "debug": "^4.3.5",
+        "debug": "^4.3.6",
         "escape-string-regexp": "^4.0.0",
         "espree": "^10.1.0",
         "esquery": "^1.6.0",
@@ -7942,10 +7956,11 @@
       }
     },
     "node_modules/jsdoc-type-pratt-parser": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-4.0.0.tgz",
-      "integrity": "sha512-YtOli5Cmzy3q4dP26GraSOeAhqecewG04hoO8DY56CH4KJ9Fvv5qKWUCCo3HZob7esJQHCv6/+bnTy72xZZaVQ==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-4.1.0.tgz",
+      "integrity": "sha512-Hicd6JK5Njt2QB6XYFS7ok9e37O8AYk3jTcppG4YVQnYjOemymvTcmc7OWsmq/Qqj5TdRFO5/x/tIPmBeRtGHg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=12.0.0"
       }
@@ -8467,9 +8482,9 @@
       }
     },
     "node_modules/npm-check-updates": {
-      "version": "17.0.3",
-      "resolved": "https://registry.npmjs.org/npm-check-updates/-/npm-check-updates-17.0.3.tgz",
-      "integrity": "sha512-3UWnsnijmx4u9GnICHVCChz6JnhVLmYWqazoedWjLSY6hZB/QhMCps07vBbDmjWnHMhpl6YseAtFlvGbUq9Yrw==",
+      "version": "17.1.0",
+      "resolved": "https://registry.npmjs.org/npm-check-updates/-/npm-check-updates-17.1.0.tgz",
+      "integrity": "sha512-RcohCA/tdpxyPllBlYDkqGXFJQgTuEt0f2oPSL9s05pZ3hxYdleaUtvEcSxKl0XAg3ncBhVgLAxhXSjoryUU5Q==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -10881,9 +10896,10 @@
       "integrity": "sha512-CC1bOL87PIWSBhDcTrdeLo6eGT7mCFtrg0uIJtqJUFyK+eJnzl8A1niH56uu7KMa5XFrtiV+AQuHO3n7DsHnLQ=="
     },
     "node_modules/winston": {
-      "version": "3.13.1",
-      "resolved": "https://registry.npmjs.org/winston/-/winston-3.13.1.tgz",
-      "integrity": "sha512-SvZit7VFNvXRzbqGHsv5KSmgbEYR5EiQfDAL9gxYkRqa934Hnk++zze0wANKtMHcy/gI4W/3xmSDwlhf865WGw==",
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-3.14.2.tgz",
+      "integrity": "sha512-CO8cdpBB2yqzEf8v895L+GNKYJiEq8eKlHU38af3snQBQ+sdAIUepjMSguOIJC7ICbzm0ZI+Af2If4vIJrtmOg==",
+      "license": "MIT",
       "dependencies": {
         "@colors/colors": "^1.6.0",
         "@dabh/diagnostics": "^2.0.2",

--- a/package.json
+++ b/package.json
@@ -85,23 +85,23 @@
     "express": "^4.19.2",
     "http-terminator": "^3.2.0",
     "node-watch": "^0.7.4",
-    "winston": "^3.13.1",
+    "winston": "^3.14.2",
     "yargs": "^17.7.2"
   },
   "devDependencies": {
     "changelog-light": "^2.0.1",
-    "cspell": "^8.13.1",
+    "cspell": "^8.14.2",
     "eslint": "^8.57.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-babel": "^5.3.1",
     "eslint-plugin-import": "^2.29.1",
-    "eslint-plugin-jest": "^28.7.0",
-    "eslint-plugin-jsdoc": "^48.11.0",
+    "eslint-plugin-jest": "^28.8.0",
+    "eslint-plugin-jsdoc": "^50.2.2",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-prettier": "^5.2.1",
     "jest": "^29.7.0",
     "nodemon": "^3.1.4",
-    "npm-check-updates": "^17.0.3",
+    "npm-check-updates": "^17.1.0",
     "npm-run-all": "^4.1.5",
     "prettier": "^3.3.3"
   }


### PR DESCRIPTION


## What's included
<!-- List your changes/additions, or commits -->
- build(deps): bump group with 5 updates
   * winston from 3.13.1 to 3.14.2
   * cspell from 8.13.1 to 8.14.2
   * eslint-plugin-jest from 28.7.0 to 28.8.0
   * eslint-plugin-jsdoc from 48.11.0 to 50.2.2
   * npm-check-updates from 17.0.3 to 17.1.0

<!-- ### Notes -->
<!-- Anything funky about your updates. Or issues that aren't resolved by this merge request, things of note? -->

## How to test
<!-- Are there directions to test/review? -->

### Coverage and basic unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm test`
1. confirm tests come back clean
<!--
### Interactive unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm run test:dev`
-->

## Example
<!-- Append a demo/screenshot/animated gif, or a link to the aforementioned, of the cli output -->
...

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
ongoing