### PR TITLE
build(deps-dev): bump group with 6 updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,19 +20,19 @@
         "mock": "bin/cli.js"
       },
       "devDependencies": {
-        "changelog-light": "^2.0.2",
-        "cspell": "^8.14.2",
+        "changelog-light": "^2.0.3",
+        "cspell": "^8.14.4",
         "eslint": "^8.57.0",
         "eslint-config-prettier": "^9.1.0",
         "eslint-plugin-babel": "^5.3.1",
-        "eslint-plugin-import": "^2.29.1",
+        "eslint-plugin-import": "^2.30.0",
         "eslint-plugin-jest": "^28.8.3",
-        "eslint-plugin-jsdoc": "^50.2.2",
+        "eslint-plugin-jsdoc": "^50.3.0",
         "eslint-plugin-node": "^11.1.0",
         "eslint-plugin-prettier": "^5.2.1",
         "jest": "^29.7.0",
-        "nodemon": "^3.1.4",
-        "npm-check-updates": "^17.1.1",
+        "nodemon": "^3.1.7",
+        "npm-check-updates": "^17.1.3",
         "npm-run-all": "^4.1.5",
         "prettier": "^3.3.3"
       },
@@ -658,35 +658,36 @@
       }
     },
     "node_modules/@cspell/cspell-bundled-dicts": {
-      "version": "8.14.2",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-bundled-dicts/-/cspell-bundled-dicts-8.14.2.tgz",
-      "integrity": "sha512-Kv2Utj/RTSxfufGXkkoTZ/3ErCsYWpCijtDFr/FwSsM7mC0PzLpdlcD9xjtgrJO5Kwp7T47iTG21U4Mwddyi8Q==",
+      "version": "8.14.4",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-bundled-dicts/-/cspell-bundled-dicts-8.14.4.tgz",
+      "integrity": "sha512-JHZOpCJzN6fPBapBOvoeMxZbr0ZA11ZAkwcqM4w0lKoacbi6TwK8GIYf66hHvwLmMeav75TNXWE6aPTvBLMMqA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@cspell/dict-ada": "^4.0.2",
-        "@cspell/dict-aws": "^4.0.3",
-        "@cspell/dict-bash": "^4.1.3",
+        "@cspell/dict-aws": "^4.0.4",
+        "@cspell/dict-bash": "^4.1.4",
         "@cspell/dict-companies": "^3.1.4",
-        "@cspell/dict-cpp": "^5.1.12",
+        "@cspell/dict-cpp": "^5.1.16",
         "@cspell/dict-cryptocurrencies": "^5.0.0",
         "@cspell/dict-csharp": "^4.0.2",
         "@cspell/dict-css": "^4.0.13",
-        "@cspell/dict-dart": "^2.0.3",
+        "@cspell/dict-dart": "^2.2.1",
         "@cspell/dict-django": "^4.1.0",
         "@cspell/dict-docker": "^1.1.7",
-        "@cspell/dict-dotnet": "^5.0.2",
+        "@cspell/dict-dotnet": "^5.0.5",
         "@cspell/dict-elixir": "^4.0.3",
         "@cspell/dict-en_us": "^4.3.23",
         "@cspell/dict-en-common-misspellings": "^2.0.4",
         "@cspell/dict-en-gb": "1.1.33",
         "@cspell/dict-filetypes": "^3.0.4",
+        "@cspell/dict-flutter": "^1.0.0",
         "@cspell/dict-fonts": "^4.0.0",
         "@cspell/dict-fsharp": "^1.0.1",
         "@cspell/dict-fullstack": "^3.2.0",
         "@cspell/dict-gaming-terms": "^1.0.5",
         "@cspell/dict-git": "^3.0.0",
-        "@cspell/dict-golang": "^6.0.9",
+        "@cspell/dict-golang": "^6.0.12",
         "@cspell/dict-google": "^1.0.1",
         "@cspell/dict-haskell": "^4.0.1",
         "@cspell/dict-html": "^4.0.5",
@@ -700,20 +701,20 @@
         "@cspell/dict-makefile": "^1.0.0",
         "@cspell/dict-monkeyc": "^1.0.6",
         "@cspell/dict-node": "^5.0.1",
-        "@cspell/dict-npm": "^5.0.18",
-        "@cspell/dict-php": "^4.0.8",
-        "@cspell/dict-powershell": "^5.0.5",
-        "@cspell/dict-public-licenses": "^2.0.7",
-        "@cspell/dict-python": "^4.2.4",
+        "@cspell/dict-npm": "^5.1.4",
+        "@cspell/dict-php": "^4.0.10",
+        "@cspell/dict-powershell": "^5.0.8",
+        "@cspell/dict-public-licenses": "^2.0.8",
+        "@cspell/dict-python": "^4.2.6",
         "@cspell/dict-r": "^2.0.1",
-        "@cspell/dict-ruby": "^5.0.2",
+        "@cspell/dict-ruby": "^5.0.3",
         "@cspell/dict-rust": "^4.0.5",
         "@cspell/dict-scala": "^5.0.3",
-        "@cspell/dict-software-terms": "^4.0.6",
+        "@cspell/dict-software-terms": "^4.1.3",
         "@cspell/dict-sql": "^2.1.5",
         "@cspell/dict-svelte": "^1.0.2",
         "@cspell/dict-swift": "^2.0.1",
-        "@cspell/dict-terraform": "^1.0.0",
+        "@cspell/dict-terraform": "^1.0.1",
         "@cspell/dict-typescript": "^3.1.6",
         "@cspell/dict-vue": "^3.0.0"
       },
@@ -722,22 +723,22 @@
       }
     },
     "node_modules/@cspell/cspell-json-reporter": {
-      "version": "8.14.2",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-json-reporter/-/cspell-json-reporter-8.14.2.tgz",
-      "integrity": "sha512-TZavcnNIZKX1xC/GNj80RgFVKHCT4pHT0qm9jCsQFH2QJfyCrUlkEvotKGSQ04lAyCwWg6Enq95qhouF8YbKUQ==",
+      "version": "8.14.4",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-json-reporter/-/cspell-json-reporter-8.14.4.tgz",
+      "integrity": "sha512-gJ6tQbGCNLyHS2iIimMg77as5MMAFv3sxU7W6tjLlZp8htiNZS7fS976g24WbT/hscsTT9Dd0sNHkpo8K3nvVw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@cspell/cspell-types": "8.14.2"
+        "@cspell/cspell-types": "8.14.4"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@cspell/cspell-pipe": {
-      "version": "8.14.2",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-pipe/-/cspell-pipe-8.14.2.tgz",
-      "integrity": "sha512-aWMoXZAXEre0/M9AYWOW33YyOJZ06i4vvsEpWBDWpHpWQEmsR/7cMMgld8Pp3wlEjIUclUAKTYmrZ61PFWU/og==",
+      "version": "8.14.4",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-pipe/-/cspell-pipe-8.14.4.tgz",
+      "integrity": "sha512-CLLdouqfrQ4rqdQdPu0Oo+HHCU/oLYoEsK1nNPb28cZTFxnn0cuSPKB6AMPBJmMwdfJ6fMD0BCKNbEe1UNLHcw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -745,9 +746,9 @@
       }
     },
     "node_modules/@cspell/cspell-resolver": {
-      "version": "8.14.2",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-resolver/-/cspell-resolver-8.14.2.tgz",
-      "integrity": "sha512-pSyBsAvslaN0dx0pHdvECJEuFDDBJGAD6G8U4BVbIyj2OPk0Ox0HrZIj6csYxxoJERAgNO/q7yCPwa4j9NNFXg==",
+      "version": "8.14.4",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-resolver/-/cspell-resolver-8.14.4.tgz",
+      "integrity": "sha512-s3uZyymJ04yn8+zlTp7Pt1WRSlAel6XVo+iZRxls3LSvIP819KK64DoyjCD2Uon0Vg9P/K7aAPt8GcxDcnJtgA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -758,9 +759,9 @@
       }
     },
     "node_modules/@cspell/cspell-service-bus": {
-      "version": "8.14.2",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-service-bus/-/cspell-service-bus-8.14.2.tgz",
-      "integrity": "sha512-WUF7xf3YgXYIqjmBwLcVugYIrYL4WfXchgSo9rmbbnOcAArzsK+HKfzb4AniZAJ1unxcIQ0JnVlRmnCAKPjjLg==",
+      "version": "8.14.4",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-service-bus/-/cspell-service-bus-8.14.4.tgz",
+      "integrity": "sha512-i3UG+ep63akNsDXZrtGgICNF3MLBHtvKe/VOIH6+L+NYaAaVHqqQvOY9MdUwt1HXh8ElzfwfoRp36wc5aAvt6g==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -768,9 +769,9 @@
       }
     },
     "node_modules/@cspell/cspell-types": {
-      "version": "8.14.2",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-types/-/cspell-types-8.14.2.tgz",
-      "integrity": "sha512-MRY8MjBNOKGMDSkxAKueYAgVL43miO+lDcLCBBP+7cNXqHiUFMIZteONcGp3kJT0dWS04dN6lKAXvaNF0aWcng==",
+      "version": "8.14.4",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-types/-/cspell-types-8.14.4.tgz",
+      "integrity": "sha512-VXwikqdHgjOVperVVCn2DOe8W3rPIswwZtMHfRYnagpzZo/TOntIjkXPJSfTtl/cFyx5DnCBsDH8ytKGlMeHkw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -903,6 +904,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@cspell/dict-flutter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-flutter/-/dict-flutter-1.0.0.tgz",
+      "integrity": "sha512-W7k1VIc4KeV8BjEBxpA3cqpzbDWjfb7oXkEb0LecBCBp5Z7kcfnjT1YVotTx/U9PGyAOBhDaEdgZACVGNQhayw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@cspell/dict-fonts": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@cspell/dict-fonts/-/dict-fonts-4.0.0.tgz",
@@ -960,9 +968,9 @@
       "license": "MIT"
     },
     "node_modules/@cspell/dict-html": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-html/-/dict-html-4.0.5.tgz",
-      "integrity": "sha512-p0brEnRybzSSWi8sGbuVEf7jSTDmXPx7XhQUb5bgG6b54uj+Z0Qf0V2n8b/LWwIPJNd1GygaO9l8k3HTCy1h4w==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-html/-/dict-html-4.0.6.tgz",
+      "integrity": "sha512-cLWHfuOhE4wqwC12up6Doxo2u1xxVhX1A8zriR4CUD+osFQzUIcBK1ykNXppga+rt1WyypaJdTU2eV6OpzYrgQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -1037,9 +1045,9 @@
       "license": "MIT"
     },
     "node_modules/@cspell/dict-npm": {
-      "version": "5.1.4",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-npm/-/dict-npm-5.1.4.tgz",
-      "integrity": "sha512-yzqVTY4P5neom4z9orV2IFOqDZ7fDotmisP7nwQkEmftoELgn5CUtNdnJhWDoDQQn6yrxOxA8jEqmyETIWzN4Q==",
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-npm/-/dict-npm-5.1.5.tgz",
+      "integrity": "sha512-oAOGWuJYU3DlO+cAsStKMWN8YEkBue25cRC9EwdiL5Z84nchU20UIoYrLfIQejMlZca+1GyrNeyxRAgn4KiivA==",
       "dev": true,
       "license": "MIT"
     },
@@ -1051,9 +1059,9 @@
       "license": "MIT"
     },
     "node_modules/@cspell/dict-powershell": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-powershell/-/dict-powershell-5.0.8.tgz",
-      "integrity": "sha512-Eg64BccQp5oEJ+V/O2G27KaLWmuOL2AWMOs2470adUihOleRfW8j9XwAEGCS+JKSnDb2mksWA72Z6kDqH138IQ==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-powershell/-/dict-powershell-5.0.9.tgz",
+      "integrity": "sha512-Vi0h0rlxS39tgTyUtxI6L3BPHH7MLPkLWCYkNfb/buQuNJYNFdHiF4bqoqVdJ/7ZrfIfNg4i6rzocnwGRn2ruw==",
       "dev": true,
       "license": "MIT"
     },
@@ -1103,9 +1111,9 @@
       "license": "MIT"
     },
     "node_modules/@cspell/dict-software-terms": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-software-terms/-/dict-software-terms-4.1.3.tgz",
-      "integrity": "sha512-5Wn5JG4IzCboX5pjISdkipsPKGaz1//iuBZdHl4US5x7mO4jOGXLpjzx6ZoPM4PXUlMEFz9NJRCDepAu8fXVtA==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-software-terms/-/dict-software-terms-4.1.4.tgz",
+      "integrity": "sha512-AHS25sYEzWze/aFglp9ODKSu+phjkuGx+OLwIcmOnvyn8axtSq5GCn9UqS4XG1/Qn0UG2Lgb4i5PJbZ0QNPNXQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -1152,9 +1160,9 @@
       "license": "MIT"
     },
     "node_modules/@cspell/dynamic-import": {
-      "version": "8.14.2",
-      "resolved": "https://registry.npmjs.org/@cspell/dynamic-import/-/dynamic-import-8.14.2.tgz",
-      "integrity": "sha512-5MbqtIligU7yPwHWU/5yFCgMvur4i1bRAF1Cy8y2dDtHsa204S/w/SaXs+51EFLp2eNbCiBisCBrwJFT7R1RxA==",
+      "version": "8.14.4",
+      "resolved": "https://registry.npmjs.org/@cspell/dynamic-import/-/dynamic-import-8.14.4.tgz",
+      "integrity": "sha512-GjKsBJvPXp4dYRqsMn7n1zpnKbnpfJnlKLOVeoFBh8fi4n06G50xYr+G25CWX1WT3WFaALAavvVICEUPrVsuqg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1165,9 +1173,9 @@
       }
     },
     "node_modules/@cspell/filetypes": {
-      "version": "8.14.2",
-      "resolved": "https://registry.npmjs.org/@cspell/filetypes/-/filetypes-8.14.2.tgz",
-      "integrity": "sha512-ZevArA0mWeVTTqHicxCPZIAeCibpY3NwWK/x6d1Lgu7RPk/daoGAM546Q2SLChFu+r10tIH7pRG212A6Q9ihPA==",
+      "version": "8.14.4",
+      "resolved": "https://registry.npmjs.org/@cspell/filetypes/-/filetypes-8.14.4.tgz",
+      "integrity": "sha512-qd68dD7xTA4Mnf/wjIKYz2SkiTBshIM+yszOUtLa06YJm0aocoNQ25FHXyYEQYm9NQXCYnRWWA02sFMGs8Sv/w==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1175,9 +1183,9 @@
       }
     },
     "node_modules/@cspell/strong-weak-map": {
-      "version": "8.14.2",
-      "resolved": "https://registry.npmjs.org/@cspell/strong-weak-map/-/strong-weak-map-8.14.2.tgz",
-      "integrity": "sha512-7sRzJc392CQYNNrtdPEfOHJdRqsqf6nASCtbS5A9hL2UrdWQ4uN7r/D+Y1HpuizwY9eOkZvarcFfsYt5wE0Pug==",
+      "version": "8.14.4",
+      "resolved": "https://registry.npmjs.org/@cspell/strong-weak-map/-/strong-weak-map-8.14.4.tgz",
+      "integrity": "sha512-Uyfck64TfVU24wAP3BLGQ5EsAfzIZiLfN90NhttpEM7GlOBmbGrEJd4hNOwfpYsE/TT80eGWQVPRTLr5SDbXFA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1185,9 +1193,9 @@
       }
     },
     "node_modules/@cspell/url": {
-      "version": "8.14.2",
-      "resolved": "https://registry.npmjs.org/@cspell/url/-/url-8.14.2.tgz",
-      "integrity": "sha512-YmWW+B/2XQcCynLpiAQF77Bitm5Cynw3/BICZkbdveKjJkUzEmXB+U2qWuwXOyU8xUYuwkP63YM8McnI567rUA==",
+      "version": "8.14.4",
+      "resolved": "https://registry.npmjs.org/@cspell/url/-/url-8.14.4.tgz",
+      "integrity": "sha512-htHhNF8WrM/NfaLSWuTYw0NqVgFRVHYSyHlRT3i/Yv5xvErld8Gw7C6ldm+0TLjoGlUe6X1VV72JSir7+yLp/Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3790,9 +3798,9 @@
       }
     },
     "node_modules/changelog-light": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/changelog-light/-/changelog-light-2.0.2.tgz",
-      "integrity": "sha512-/0uNISVeK+Rag+5CiTeztYN2gyEyRvGn1e3epo+iiaBqaaTjMO33SIJFaKwDR87LxYMvjhUuAX/bD4t9swNbww==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/changelog-light/-/changelog-light-2.0.3.tgz",
+      "integrity": "sha512-l2EpqUfoOY1mKaTNrmeJ+hi8ExlYeHFfPL6/6lO0kKphWILQo9Ehm52Lehm3NrrWT4g4yOewvgmWtRXzduHvBQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4209,28 +4217,28 @@
       }
     },
     "node_modules/cspell": {
-      "version": "8.14.2",
-      "resolved": "https://registry.npmjs.org/cspell/-/cspell-8.14.2.tgz",
-      "integrity": "sha512-ii/W7fwO4chNQVYl1C/8k7RW8EXzLb69rvg08p8mSJx8B2UasVJ9tuJpTH2Spo1jX6N3H0dKPWUbd1fAmdAhPg==",
+      "version": "8.14.4",
+      "resolved": "https://registry.npmjs.org/cspell/-/cspell-8.14.4.tgz",
+      "integrity": "sha512-R5Awb3i/RKaVVcZzFt8dkN3M6VnifIEDYBcbzbmYjZ/Eq+ASF+QTmI0E9WPhMEcFM1nd7YOyXnETo560yRdoKw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@cspell/cspell-json-reporter": "8.14.2",
-        "@cspell/cspell-pipe": "8.14.2",
-        "@cspell/cspell-types": "8.14.2",
-        "@cspell/dynamic-import": "8.14.2",
-        "@cspell/url": "8.14.2",
+        "@cspell/cspell-json-reporter": "8.14.4",
+        "@cspell/cspell-pipe": "8.14.4",
+        "@cspell/cspell-types": "8.14.4",
+        "@cspell/dynamic-import": "8.14.4",
+        "@cspell/url": "8.14.4",
         "chalk": "^5.3.0",
         "chalk-template": "^1.1.0",
         "commander": "^12.1.0",
-        "cspell-dictionary": "8.14.2",
-        "cspell-gitignore": "8.14.2",
-        "cspell-glob": "8.14.2",
-        "cspell-io": "8.14.2",
-        "cspell-lib": "8.14.2",
+        "cspell-dictionary": "8.14.4",
+        "cspell-gitignore": "8.14.4",
+        "cspell-glob": "8.14.4",
+        "cspell-io": "8.14.4",
+        "cspell-lib": "8.14.4",
         "fast-glob": "^3.3.2",
         "fast-json-stable-stringify": "^2.1.0",
-        "file-entry-cache": "^9.0.0",
+        "file-entry-cache": "^9.1.0",
         "get-stdin": "^9.0.0",
         "semver": "^7.6.3",
         "strip-ansi": "^7.1.0"
@@ -4247,30 +4255,30 @@
       }
     },
     "node_modules/cspell-config-lib": {
-      "version": "8.14.2",
-      "resolved": "https://registry.npmjs.org/cspell-config-lib/-/cspell-config-lib-8.14.2.tgz",
-      "integrity": "sha512-yHP1BdcH5dbjb8qiZr6+bxEnJ+rxTULQ00wBz3eBPWCghJywEAYYvMWoYuxVtPpndlkKYC1wJAHsyNkweQyepA==",
+      "version": "8.14.4",
+      "resolved": "https://registry.npmjs.org/cspell-config-lib/-/cspell-config-lib-8.14.4.tgz",
+      "integrity": "sha512-cnUeJfniTiebqCaQmIUnbSrPrTH7xzKRQjJDHAEV0WYnOG2MhRXI13OzytdFdhkVBdStmgTzTCJKE7x+kmU2NA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@cspell/cspell-types": "8.14.2",
+        "@cspell/cspell-types": "8.14.4",
         "comment-json": "^4.2.5",
-        "yaml": "^2.5.0"
+        "yaml": "^2.5.1"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/cspell-dictionary": {
-      "version": "8.14.2",
-      "resolved": "https://registry.npmjs.org/cspell-dictionary/-/cspell-dictionary-8.14.2.tgz",
-      "integrity": "sha512-gWuAvf6queGGUvGbfAxxUq55cZ0OevWPbjnCrSB0PpJ4tqdFd8dLcvVrIKzoE2sBXKPw2NDkmoEngs6iGavC0w==",
+      "version": "8.14.4",
+      "resolved": "https://registry.npmjs.org/cspell-dictionary/-/cspell-dictionary-8.14.4.tgz",
+      "integrity": "sha512-pZvQHxpAW5fZAnt3ZKKy3s7M+3CX2t8tCS3uJrpEHIynlCawpG0fPF78rVE5o+g0dON36Lguc/BUuSN4IWKLmQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@cspell/cspell-pipe": "8.14.2",
-        "@cspell/cspell-types": "8.14.2",
-        "cspell-trie-lib": "8.14.2",
+        "@cspell/cspell-pipe": "8.14.4",
+        "@cspell/cspell-types": "8.14.4",
+        "cspell-trie-lib": "8.14.4",
         "fast-equals": "^5.0.1"
       },
       "engines": {
@@ -4278,15 +4286,15 @@
       }
     },
     "node_modules/cspell-gitignore": {
-      "version": "8.14.2",
-      "resolved": "https://registry.npmjs.org/cspell-gitignore/-/cspell-gitignore-8.14.2.tgz",
-      "integrity": "sha512-lrO/49NaKBpkR7vFxv4OOY+oHmsG5+gNQejrBBWD9Nv9vvjJtz/G36X/rcN6M6tFcQQMWwa01kf04nxz8Ejuhg==",
+      "version": "8.14.4",
+      "resolved": "https://registry.npmjs.org/cspell-gitignore/-/cspell-gitignore-8.14.4.tgz",
+      "integrity": "sha512-RwfQEW5hD7CpYwS7m3b0ONG0nTLKP6bL2tvMdl7qtaYkL7ztGdsBTtLD1pmwqUsCbiN5RuaOxhYOYeRcpFRIkQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@cspell/url": "8.14.2",
-        "cspell-glob": "8.14.2",
-        "cspell-io": "8.14.2",
+        "@cspell/url": "8.14.4",
+        "cspell-glob": "8.14.4",
+        "cspell-io": "8.14.4",
         "find-up-simple": "^1.0.0"
       },
       "bin": {
@@ -4297,28 +4305,28 @@
       }
     },
     "node_modules/cspell-glob": {
-      "version": "8.14.2",
-      "resolved": "https://registry.npmjs.org/cspell-glob/-/cspell-glob-8.14.2.tgz",
-      "integrity": "sha512-9Q1Kgoo1ev3fKTpp9y5n8M4RLxd8B0f5o4y5FQe4dBU0j/bt+/YDrLZNWDm77JViV606XQ6fimG1FTTq6pT9/g==",
+      "version": "8.14.4",
+      "resolved": "https://registry.npmjs.org/cspell-glob/-/cspell-glob-8.14.4.tgz",
+      "integrity": "sha512-C/xTS5nujMRMuguibq92qMVP767mtxrur7DcVolCvpzcivm1RB5NtIN0OctQxTyMbnmKeQv1t4epRKQ9A8vWRg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@cspell/url": "8.14.2",
-        "micromatch": "^4.0.7"
+        "@cspell/url": "8.14.4",
+        "micromatch": "^4.0.8"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/cspell-grammar": {
-      "version": "8.14.2",
-      "resolved": "https://registry.npmjs.org/cspell-grammar/-/cspell-grammar-8.14.2.tgz",
-      "integrity": "sha512-eYwceVP80FGYVJenE42ALnvEKOXaXjq4yVbb1Ni1umO/9qamLWNCQ1RP6rRACy5e/cXviAbhrQ5Mtw6n+pyPEQ==",
+      "version": "8.14.4",
+      "resolved": "https://registry.npmjs.org/cspell-grammar/-/cspell-grammar-8.14.4.tgz",
+      "integrity": "sha512-yaSKAAJDiamsw3FChbw4HXb2RvTQrDsLelh1+T4MavarOIcAxXrqAJ8ysqm++g+S/ooJz2YO8YWIyzJKxcMf8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@cspell/cspell-pipe": "8.14.2",
-        "@cspell/cspell-types": "8.14.2"
+        "@cspell/cspell-pipe": "8.14.4",
+        "@cspell/cspell-types": "8.14.4"
       },
       "bin": {
         "cspell-grammar": "bin.mjs"
@@ -4328,42 +4336,42 @@
       }
     },
     "node_modules/cspell-io": {
-      "version": "8.14.2",
-      "resolved": "https://registry.npmjs.org/cspell-io/-/cspell-io-8.14.2.tgz",
-      "integrity": "sha512-uaKpHiY3DAgfdzgKMQml6U8F8o9udMuYxGqYa5FVfN7D5Ap7B2edQzSLTUYwxrFEn4skSfp6XY73+nzJvxzH4Q==",
+      "version": "8.14.4",
+      "resolved": "https://registry.npmjs.org/cspell-io/-/cspell-io-8.14.4.tgz",
+      "integrity": "sha512-o6OTWRyx/Az+PFhr1B0wMAwqG070hFC9g73Fkxd8+rHX0rfRS69QZH7LgSmZytqbZIMxCTDGdsLl33MFGWCbZQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@cspell/cspell-service-bus": "8.14.2",
-        "@cspell/url": "8.14.2"
+        "@cspell/cspell-service-bus": "8.14.4",
+        "@cspell/url": "8.14.4"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/cspell-lib": {
-      "version": "8.14.2",
-      "resolved": "https://registry.npmjs.org/cspell-lib/-/cspell-lib-8.14.2.tgz",
-      "integrity": "sha512-d2oiIXHXnADmnhIuFLOdNE63L7OUfzgpLbYaqAWbkImCUDkevfGrOgnX8TJ03fUgZID4nvQ+3kgu/n2j4eLZjQ==",
+      "version": "8.14.4",
+      "resolved": "https://registry.npmjs.org/cspell-lib/-/cspell-lib-8.14.4.tgz",
+      "integrity": "sha512-qdkUkKtm+nmgpA4jQbmQTuepDfjHBDWvs3zDuEwVIVFq/h8gnXrRr75gJ3RYdTy+vOOqHPoLLqgxyqkUUrUGXA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@cspell/cspell-bundled-dicts": "8.14.2",
-        "@cspell/cspell-pipe": "8.14.2",
-        "@cspell/cspell-resolver": "8.14.2",
-        "@cspell/cspell-types": "8.14.2",
-        "@cspell/dynamic-import": "8.14.2",
-        "@cspell/filetypes": "8.14.2",
-        "@cspell/strong-weak-map": "8.14.2",
-        "@cspell/url": "8.14.2",
+        "@cspell/cspell-bundled-dicts": "8.14.4",
+        "@cspell/cspell-pipe": "8.14.4",
+        "@cspell/cspell-resolver": "8.14.4",
+        "@cspell/cspell-types": "8.14.4",
+        "@cspell/dynamic-import": "8.14.4",
+        "@cspell/filetypes": "8.14.4",
+        "@cspell/strong-weak-map": "8.14.4",
+        "@cspell/url": "8.14.4",
         "clear-module": "^4.1.2",
         "comment-json": "^4.2.5",
-        "cspell-config-lib": "8.14.2",
-        "cspell-dictionary": "8.14.2",
-        "cspell-glob": "8.14.2",
-        "cspell-grammar": "8.14.2",
-        "cspell-io": "8.14.2",
-        "cspell-trie-lib": "8.14.2",
+        "cspell-config-lib": "8.14.4",
+        "cspell-dictionary": "8.14.4",
+        "cspell-glob": "8.14.4",
+        "cspell-grammar": "8.14.4",
+        "cspell-io": "8.14.4",
+        "cspell-trie-lib": "8.14.4",
         "env-paths": "^3.0.0",
         "fast-equals": "^5.0.1",
         "gensequence": "^7.0.0",
@@ -4378,14 +4386,14 @@
       }
     },
     "node_modules/cspell-trie-lib": {
-      "version": "8.14.2",
-      "resolved": "https://registry.npmjs.org/cspell-trie-lib/-/cspell-trie-lib-8.14.2.tgz",
-      "integrity": "sha512-rZMbaEBGoyy4/zxKECaMyVyGLbuUxYmZ5jlEgiA3xPtEdWwJ4iWRTo5G6dWbQsXoxPYdAXXZ0/q0GQ2y6Jt0kw==",
+      "version": "8.14.4",
+      "resolved": "https://registry.npmjs.org/cspell-trie-lib/-/cspell-trie-lib-8.14.4.tgz",
+      "integrity": "sha512-zu8EJ33CH+FA5lwTRGqS//Q6phO0qtgEmODMR1KPlD7WlrfTFMb3bWFsLo/tiv5hjpsn7CM6dYDAAgBOSkoyhQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@cspell/cspell-pipe": "8.14.2",
-        "@cspell/cspell-types": "8.14.2",
+        "@cspell/cspell-pipe": "8.14.4",
+        "@cspell/cspell-types": "8.14.4",
         "gensequence": "^7.0.0"
       },
       "engines": {
@@ -5199,9 +5207,9 @@
       }
     },
     "node_modules/eslint-plugin-jsdoc": {
-      "version": "50.2.2",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-50.2.2.tgz",
-      "integrity": "sha512-i0ZMWA199DG7sjxlzXn5AeYZxpRfMJjDPUl7lL9eJJX8TPRoIaxJU4ys/joP5faM5AXE1eqW/dslCj3uj4Nqpg==",
+      "version": "50.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-50.3.0.tgz",
+      "integrity": "sha512-P7qDB/RckdKETpBM4CtjHRQ5qXByPmFhRi86sN3E+J+tySchq+RSOGGhI2hDIefmmKFuTi/1ACjqsnDJDDDfzg==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -8907,9 +8915,9 @@
       }
     },
     "node_modules/nodemon": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-3.1.4.tgz",
-      "integrity": "sha512-wjPBbFhtpJwmIeY2yP7QF+UKzPfltVGtfce1g/bB15/8vCGZj8uxD62b/b9M9/WVgme0NZudpownKN+c0plXlQ==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-3.1.7.tgz",
+      "integrity": "sha512-hLj7fuMow6f0lbB0cD14Lz2xNjwsyruH251Pk4t/yIitCFJbmY1myuLlHm/q06aST4jg6EgAh74PIBBrRqpVAQ==",
       "license": "MIT",
       "dependencies": {
         "chokidar": "^3.5.2",
@@ -8988,9 +8996,9 @@
       }
     },
     "node_modules/npm-check-updates": {
-      "version": "17.1.1",
-      "resolved": "https://registry.npmjs.org/npm-check-updates/-/npm-check-updates-17.1.1.tgz",
-      "integrity": "sha512-2aqIzGAEWB7xPf0hKHTkNmUM5jHbn2S5r2/z/7dA5Ij2h/sVYAg9R/uVkaUC3VORPAfBm7pKkCWo6E9clEVQ9A==",
+      "version": "17.1.3",
+      "resolved": "https://registry.npmjs.org/npm-check-updates/-/npm-check-updates-17.1.3.tgz",
+      "integrity": "sha512-4uDLBWPuDHT5KLieIJ20FoAB8yqJejmupI42wPyfObgQOBbPAikQSwT73afDwREvhuxYrRDqlRvxTMSfvO+L8A==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -89,19 +89,19 @@
     "yargs": "^17.7.2"
   },
   "devDependencies": {
-    "changelog-light": "^2.0.2",
-    "cspell": "^8.14.2",
+    "changelog-light": "^2.0.3",
+    "cspell": "^8.14.4",
     "eslint": "^8.57.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-babel": "^5.3.1",
-    "eslint-plugin-import": "^2.29.1",
+    "eslint-plugin-import": "^2.30.0",
     "eslint-plugin-jest": "^28.8.3",
-    "eslint-plugin-jsdoc": "^50.2.2",
+    "eslint-plugin-jsdoc": "^50.3.0",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-prettier": "^5.2.1",
     "jest": "^29.7.0",
-    "nodemon": "^3.1.4",
-    "npm-check-updates": "^17.1.1",
+    "nodemon": "^3.1.7",
+    "npm-check-updates": "^17.1.3",
     "npm-run-all": "^4.1.5",
     "prettier": "^3.3.3"
   }


### PR DESCRIPTION


## What's included
<!-- List your changes/additions, or commits -->
- build(deps-dev): bump group with 6 updates
   * changelog-light from 2.0.2 to 2.0.3
   * cspell from 8.14.2 to 8.14.4
   * eslint-plugin-import from 2.29.1 to 2.30.0
   * eslint-plugin-jsdoc from 50.2.2 to 50.3.0
   * nodemon from 3.1.4 to 3.1.7
   * npm-check-updates from 17.1.1 to 17.1.3

<!-- ### Notes -->
<!-- Anything funky about your updates. Or issues that aren't resolved by this merge request, things of note? -->

## How to test
<!-- Are there directions to test/review? -->

### Coverage and basic unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm test`
1. confirm tests come back clean
<!--
### Interactive unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm run test:dev`
-->

## Example
<!-- Append a demo/screenshot/animated gif, or a link to the aforementioned, of the cli output -->
...

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
ongoing