### PR TITLE
build(deps): bump group with 2 updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,10 +10,10 @@
       "license": "MIT",
       "dependencies": {
         "apidoc": "1.2.0",
-        "express": "^4.21.0",
+        "express": "^4.21.1",
         "http-terminator": "^3.2.0",
         "node-watch": "^0.7.4",
-        "winston": "^3.14.2",
+        "winston": "^3.15.0",
         "yargs": "^17.7.2"
       },
       "bin": {
@@ -4093,9 +4093,9 @@
       "license": "MIT"
     },
     "node_modules/cookie": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
-      "integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.1.tgz",
+      "integrity": "sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -5643,9 +5643,9 @@
       }
     },
     "node_modules/express": {
-      "version": "4.21.0",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.21.0.tgz",
-      "integrity": "sha512-VqcNGcj/Id5ZT1LZ/cfihi3ttTn+NJmkli2eZADigjq29qTlWi/hAQ43t/VLPq8+UX06FCEx3ByOYet6ZFblng==",
+      "version": "4.21.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.21.1.tgz",
+      "integrity": "sha512-YSFlK1Ee0/GC8QaO91tHcDxJiE/X4FbpAyQWkxAvG6AXCuR65YzK8ua6D9hvi/TzUfZMpc+BwuM1IPw8fmQBiQ==",
       "license": "MIT",
       "dependencies": {
         "accepts": "~1.3.8",
@@ -5653,7 +5653,7 @@
         "body-parser": "1.20.3",
         "content-disposition": "0.5.4",
         "content-type": "~1.0.4",
-        "cookie": "0.6.0",
+        "cookie": "0.7.1",
         "cookie-signature": "1.0.6",
         "debug": "2.6.9",
         "depd": "2.0.0",
@@ -11616,9 +11616,9 @@
       "license": "MIT"
     },
     "node_modules/winston": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/winston/-/winston-3.14.2.tgz",
-      "integrity": "sha512-CO8cdpBB2yqzEf8v895L+GNKYJiEq8eKlHU38af3snQBQ+sdAIUepjMSguOIJC7ICbzm0ZI+Af2If4vIJrtmOg==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-3.15.0.tgz",
+      "integrity": "sha512-RhruH2Cj0bV0WgNL+lOfoUBI4DVfdUNjVnJGVovWZmrcKtrFTTRzgXYK2O9cymSGjrERCtaAeHwMNnUWXlwZow==",
       "license": "MIT",
       "dependencies": {
         "@colors/colors": "^1.6.0",

--- a/package.json
+++ b/package.json
@@ -82,10 +82,10 @@
   },
   "dependencies": {
     "apidoc": "1.2.0",
-    "express": "^4.21.0",
+    "express": "^4.21.1",
     "http-terminator": "^3.2.0",
     "node-watch": "^0.7.4",
-    "winston": "^3.14.2",
+    "winston": "^3.15.0",
     "yargs": "^17.7.2"
   },
   "devDependencies": {


### PR DESCRIPTION


## What's included
<!-- List your changes/additions, or commits -->
- build(deps): bump group with 2 updates
   * express from 4.21.0 to 4.21.1
   * winston from 3.14.2 to 3.15.0

<!-- ### Notes -->
<!-- Anything funky about your updates. Or issues that aren't resolved by this merge request, things of note? -->

## How to test
<!-- Are there directions to test/review? -->

### Coverage and basic unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm test`
1. confirm tests come back clean
<!--
### Interactive unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm run test:dev`
-->

## Example
<!-- Append a demo/screenshot/animated gif, or a link to the aforementioned, of the cli output -->
...

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
ongoing