### PR TITLE
build(deps): bump group with 5 updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "express": "^4.21.1",
         "http-terminator": "^3.2.0",
         "node-watch": "^0.7.4",
-        "winston": "^3.15.0",
+        "winston": "^3.17.0",
         "yargs": "^17.7.2"
       },
       "bin": {
@@ -21,18 +21,18 @@
       },
       "devDependencies": {
         "changelog-light": "^2.0.3",
-        "cspell": "^8.15.2",
+        "cspell": "^8.16.0",
         "eslint": "^8.57.0",
         "eslint-config-prettier": "^9.1.0",
         "eslint-plugin-babel": "^5.3.1",
         "eslint-plugin-import": "^2.31.0",
-        "eslint-plugin-jest": "^28.8.3",
-        "eslint-plugin-jsdoc": "^50.4.1",
+        "eslint-plugin-jest": "^28.9.0",
+        "eslint-plugin-jsdoc": "^50.5.0",
         "eslint-plugin-node": "^11.1.0",
         "eslint-plugin-prettier": "^5.2.1",
         "jest": "^29.7.0",
         "nodemon": "^3.1.7",
-        "npm-check-updates": "^17.1.3",
+        "npm-check-updates": "^17.1.11",
         "npm-run-all": "^4.1.5",
         "prettier": "^3.3.3"
       },
@@ -658,29 +658,30 @@
       }
     },
     "node_modules/@cspell/cspell-bundled-dicts": {
-      "version": "8.15.2",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-bundled-dicts/-/cspell-bundled-dicts-8.15.2.tgz",
-      "integrity": "sha512-e+hxoD/GW7iyK1zMeRFd10yBr9tcClnnqFLxJM+tH1cSzLQ66ouXMIMuJpcd8LOCm7zMRdjTm4R72LehMgL79g==",
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-bundled-dicts/-/cspell-bundled-dicts-8.16.0.tgz",
+      "integrity": "sha512-R0Eqq5kTZnmZ0elih5uY3TWjMqqAeMl7ciU7maUs+m1FNjCEdJXtJ9wrQxNgjmXi0tX8cvahZRO3O558tEz/KA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@cspell/dict-ada": "^4.0.5",
+        "@cspell/dict-al": "^1.0.3",
         "@cspell/dict-aws": "^4.0.7",
         "@cspell/dict-bash": "^4.1.8",
         "@cspell/dict-companies": "^3.1.7",
-        "@cspell/dict-cpp": "^5.1.22",
+        "@cspell/dict-cpp": "^6.0.1",
         "@cspell/dict-cryptocurrencies": "^5.0.3",
         "@cspell/dict-csharp": "^4.0.5",
         "@cspell/dict-css": "^4.0.16",
         "@cspell/dict-dart": "^2.2.4",
         "@cspell/dict-django": "^4.1.3",
-        "@cspell/dict-docker": "^1.1.10",
+        "@cspell/dict-docker": "^1.1.11",
         "@cspell/dict-dotnet": "^5.0.8",
         "@cspell/dict-elixir": "^4.0.6",
         "@cspell/dict-en_us": "^4.3.26",
         "@cspell/dict-en-common-misspellings": "^2.0.7",
         "@cspell/dict-en-gb": "1.1.33",
-        "@cspell/dict-filetypes": "^3.0.7",
+        "@cspell/dict-filetypes": "^3.0.8",
         "@cspell/dict-flutter": "^1.0.3",
         "@cspell/dict-fonts": "^4.0.3",
         "@cspell/dict-fsharp": "^1.0.4",
@@ -690,7 +691,7 @@
         "@cspell/dict-golang": "^6.0.16",
         "@cspell/dict-google": "^1.0.4",
         "@cspell/dict-haskell": "^4.0.4",
-        "@cspell/dict-html": "^4.0.9",
+        "@cspell/dict-html": "^4.0.10",
         "@cspell/dict-html-symbol-entities": "^4.0.3",
         "@cspell/dict-java": "^5.0.10",
         "@cspell/dict-julia": "^1.0.4",
@@ -699,23 +700,24 @@
         "@cspell/dict-lorem-ipsum": "^4.0.3",
         "@cspell/dict-lua": "^4.0.6",
         "@cspell/dict-makefile": "^1.0.3",
+        "@cspell/dict-markdown": "^2.0.7",
         "@cspell/dict-monkeyc": "^1.0.9",
-        "@cspell/dict-node": "^5.0.4",
-        "@cspell/dict-npm": "^5.1.8",
+        "@cspell/dict-node": "^5.0.5",
+        "@cspell/dict-npm": "^5.1.11",
         "@cspell/dict-php": "^4.0.13",
         "@cspell/dict-powershell": "^5.0.13",
         "@cspell/dict-public-licenses": "^2.0.11",
-        "@cspell/dict-python": "^4.2.11",
+        "@cspell/dict-python": "^4.2.12",
         "@cspell/dict-r": "^2.0.4",
         "@cspell/dict-ruby": "^5.0.7",
         "@cspell/dict-rust": "^4.0.9",
         "@cspell/dict-scala": "^5.0.6",
-        "@cspell/dict-software-terms": "^4.1.10",
+        "@cspell/dict-software-terms": "^4.1.13",
         "@cspell/dict-sql": "^2.1.8",
         "@cspell/dict-svelte": "^1.0.5",
         "@cspell/dict-swift": "^2.0.4",
-        "@cspell/dict-terraform": "^1.0.5",
-        "@cspell/dict-typescript": "^3.1.9",
+        "@cspell/dict-terraform": "^1.0.6",
+        "@cspell/dict-typescript": "^3.1.11",
         "@cspell/dict-vue": "^3.0.3"
       },
       "engines": {
@@ -723,22 +725,22 @@
       }
     },
     "node_modules/@cspell/cspell-json-reporter": {
-      "version": "8.15.2",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-json-reporter/-/cspell-json-reporter-8.15.2.tgz",
-      "integrity": "sha512-6p9eLdO5RLb1HNf+Rto4RG3tG02y05DutrWdpnK1Agn21EbUKAUIdIcsjQ2N52UeVT5cDvNhkAabKN57sFygag==",
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-json-reporter/-/cspell-json-reporter-8.16.0.tgz",
+      "integrity": "sha512-KLjPK94gA3JNuWy70LeenJ6EL3SFk2ejERKYJ6SVV/cVOKIvVd2qe42yX3/A/DkF2xzuZ2LD4z0sfoqQL1BaqA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@cspell/cspell-types": "8.15.2"
+        "@cspell/cspell-types": "8.16.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@cspell/cspell-pipe": {
-      "version": "8.15.2",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-pipe/-/cspell-pipe-8.15.2.tgz",
-      "integrity": "sha512-TOcLiRiUSh75y+DQrAW59Ix0/D9WPrd4/KPtUShUepS3vLfoxMQ+TwpXfdc8FrzU73Hg5glXXnQjvdx7vAazVQ==",
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-pipe/-/cspell-pipe-8.16.0.tgz",
+      "integrity": "sha512-WoCgrv/mrtwCY4lhc6vEcqN3AQ7lT6K0NW5ShoSo116U2tRaW0unApIYH4Va8u7T9g3wyspFEceQRR1xD9qb9w==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -746,9 +748,9 @@
       }
     },
     "node_modules/@cspell/cspell-resolver": {
-      "version": "8.15.2",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-resolver/-/cspell-resolver-8.15.2.tgz",
-      "integrity": "sha512-XOcHfkKCN+a3zZMexK/BLmDxsqku8Q5ASqYu7JBFsu/axS4K11bkcQMxYoOvHVGBv20vb/gM2D+9MePuxAfssg==",
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-resolver/-/cspell-resolver-8.16.0.tgz",
+      "integrity": "sha512-b+99bph43ptkXlQHgPXSkN/jK6LQHy2zL1Fm9up7+x6Yr64bxAzWzoeqJAPtnrPvFuOrFN0jZasZzKBw8CvrrQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -759,9 +761,9 @@
       }
     },
     "node_modules/@cspell/cspell-service-bus": {
-      "version": "8.15.2",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-service-bus/-/cspell-service-bus-8.15.2.tgz",
-      "integrity": "sha512-g9rhMIU0DX+avIQHFu0Mx3LAFi4lG6zX8iFa2zu+u3ll0IX0WtxTqrzft27jYSwebmm/ysWJUcOY+SWhZfPA0Q==",
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-service-bus/-/cspell-service-bus-8.16.0.tgz",
+      "integrity": "sha512-+fn763JKA4EYCOv+1VShFq015UMEBAFRDr+rlCnesgLE0fv9TSFVLsjOfh9/g6GuGQLCRLUqKztwwuueeErstQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -769,9 +771,9 @@
       }
     },
     "node_modules/@cspell/cspell-types": {
-      "version": "8.15.2",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-types/-/cspell-types-8.15.2.tgz",
-      "integrity": "sha512-bHAkXsrfOhKyZZ+TA5eGH3fqh9DPcP3a2v+ozTnhhZa3zcfuzX7rZnYWEFA8LELMUStWXLECzFoGd9QUEHMstg==",
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-types/-/cspell-types-8.16.0.tgz",
+      "integrity": "sha512-bGrIK7p4NVsK+QX/CYWmjax+FkzfSIZaIaoiBESGV5gmwgXDVRMJ3IP6tQVAmTtckOYHCmtT5CZgI8zXWr8dHQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -782,6 +784,13 @@
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/@cspell/dict-ada/-/dict-ada-4.0.5.tgz",
       "integrity": "sha512-6/RtZ/a+lhFVmrx/B7bfP7rzC4yjEYe8o74EybXcvu4Oue6J4Ey2WSYj96iuodloj1LWrkNCQyX5h4Pmcj0Iag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-al": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-al/-/dict-al-1.0.3.tgz",
+      "integrity": "sha512-V1HClwlfU/qwSq2Kt+MkqRAsonNu3mxjSCDyGRecdLGIHmh7yeEeaxqRiO/VZ4KP+eVSiSIlbwrb5YNFfxYZbw==",
       "dev": true,
       "license": "MIT"
     },
@@ -807,9 +816,9 @@
       "license": "MIT"
     },
     "node_modules/@cspell/dict-cpp": {
-      "version": "5.1.22",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-cpp/-/dict-cpp-5.1.22.tgz",
-      "integrity": "sha512-g1/8P5/Q+xnIc8Js4UtBg3XOhcFrFlFbG3UWVtyEx49YTf0r9eyDtDt1qMMDBZT91pyCwLcAEbwS+4i5PIfNZw==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-cpp/-/dict-cpp-6.0.2.tgz",
+      "integrity": "sha512-yw5eejWvY4bAnc6LUA44m4WsFwlmgPt2uMSnO7QViGMBDuoeopMma4z9XYvs4lSjTi8fIJs/A1YDfM9AVzb8eg==",
       "dev": true,
       "license": "MIT"
     },
@@ -856,9 +865,9 @@
       "license": "MIT"
     },
     "node_modules/@cspell/dict-docker": {
-      "version": "1.1.10",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-docker/-/dict-docker-1.1.10.tgz",
-      "integrity": "sha512-vWybMfsG/8jhN6kmPoilMon36GB3+Ef+m/mgYUfY8tJN23K/x4KD1rU1OOiNWzDqePhu3MMWVKO5W5x6VI6Gbw==",
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-docker/-/dict-docker-1.1.11.tgz",
+      "integrity": "sha512-s0Yhb16/R+UT1y727ekbR/itWQF3Qz275DR1ahOa66wYtPjHUXmhM3B/LT3aPaX+hD6AWmK23v57SuyfYHUjsw==",
       "dev": true,
       "license": "MIT"
     },
@@ -877,9 +886,9 @@
       "license": "MIT"
     },
     "node_modules/@cspell/dict-en_us": {
-      "version": "4.3.26",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-en_us/-/dict-en_us-4.3.26.tgz",
-      "integrity": "sha512-hDbHYJsi3UgU1J++B0WLiYhWQdsmve3CH53FIaMRAdhrWOHcuw7h1dYkQXHFEP5lOjaq53KUHp/oh5su6VkIZg==",
+      "version": "4.3.27",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-en_us/-/dict-en_us-4.3.27.tgz",
+      "integrity": "sha512-7JYHahRWpi0VykWFTSM03KL/0fs6YtYfpOaTAg4N/d0wB2GfwVG/FJ/SBCjD4LBc6Rx9dzdo95Hs4BB8GPQbOA==",
       "dev": true,
       "license": "MIT"
     },
@@ -898,9 +907,9 @@
       "license": "MIT"
     },
     "node_modules/@cspell/dict-filetypes": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-filetypes/-/dict-filetypes-3.0.7.tgz",
-      "integrity": "sha512-/DN0Ujp9/EXvpTcgih9JmBaE8n+G0wtsspyNdvHT5luRfpfol1xm/CIQb6xloCXCiLkWX+EMPeLSiVIZq+24dA==",
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-filetypes/-/dict-filetypes-3.0.8.tgz",
+      "integrity": "sha512-D3N8sm/iptzfVwsib/jvpX+K/++rM8SRpLDFUaM4jxm8EyGmSIYRbKZvdIv5BkAWmMlTWoRqlLn7Yb1b11jKJg==",
       "dev": true,
       "license": "MIT"
     },
@@ -947,9 +956,9 @@
       "license": "MIT"
     },
     "node_modules/@cspell/dict-golang": {
-      "version": "6.0.16",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-golang/-/dict-golang-6.0.16.tgz",
-      "integrity": "sha512-hZOBlgcguv2Hdc93n2zjdAQm1j3grsN9T9WhPnQ1wh2vUDoCLEujg+6gWhjcLb8ECOcwZTWgNyQLWeOxEsAj/w==",
+      "version": "6.0.17",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-golang/-/dict-golang-6.0.17.tgz",
+      "integrity": "sha512-uDDLEJ/cHdLiqPw4+5BnmIo2i/TSR+uDvYd6JlBjTmjBKpOCyvUgYRztH7nv5e7virsN5WDiUWah4/ATQGz4Pw==",
       "dev": true,
       "license": "MIT"
     },
@@ -968,9 +977,9 @@
       "license": "MIT"
     },
     "node_modules/@cspell/dict-html": {
-      "version": "4.0.9",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-html/-/dict-html-4.0.9.tgz",
-      "integrity": "sha512-BNp7w3m910K4qIVyOBOZxHuFNbVojUY6ES8Y8r7YjYgJkm2lCuQoVwwhPjurnomJ7BPmZTb+3LLJ58XIkgF7JQ==",
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-html/-/dict-html-4.0.10.tgz",
+      "integrity": "sha512-I9uRAcdtHbh0wEtYZlgF0TTcgH0xaw1B54G2CW+tx4vHUwlde/+JBOfIzird4+WcMv4smZOfw+qHf7puFUbI5g==",
       "dev": true,
       "license": "MIT"
     },
@@ -1030,6 +1039,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@cspell/dict-markdown": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-markdown/-/dict-markdown-2.0.7.tgz",
+      "integrity": "sha512-F9SGsSOokFn976DV4u/1eL4FtKQDSgJHSZ3+haPRU5ki6OEqojxKa8hhj4AUrtNFpmBaJx/WJ4YaEzWqG7hgqg==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@cspell/dict-css": "^4.0.16",
+        "@cspell/dict-html": "^4.0.10",
+        "@cspell/dict-html-symbol-entities": "^4.0.3",
+        "@cspell/dict-typescript": "^3.1.11"
+      }
+    },
     "node_modules/@cspell/dict-monkeyc": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@cspell/dict-monkeyc/-/dict-monkeyc-1.0.9.tgz",
@@ -1038,16 +1060,16 @@
       "license": "MIT"
     },
     "node_modules/@cspell/dict-node": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-node/-/dict-node-5.0.4.tgz",
-      "integrity": "sha512-Hz5hiuOvZTd7Cp1IBqUZ7/ChwJeQpD5BJuwCaDn4mPNq4iMcQ1iWBYMThvNVqCEDgKv63X52nT8RAWacss98qg==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-node/-/dict-node-5.0.5.tgz",
+      "integrity": "sha512-7NbCS2E8ZZRZwlLrh2sA0vAk9n1kcTUiRp/Nia8YvKaItGXLfxYqD2rMQ3HpB1kEutal6hQLVic3N2Yi1X7AaA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@cspell/dict-npm": {
-      "version": "5.1.8",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-npm/-/dict-npm-5.1.8.tgz",
-      "integrity": "sha512-AJELYXeB4fQdIoNfmuaQxB1Hli3cX6XPsQCjfBxlu0QYXhrjB/IrCLLQAjWIywDqJiWyGUFTz4DqaANm8C/r9Q==",
+      "version": "5.1.13",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-npm/-/dict-npm-5.1.13.tgz",
+      "integrity": "sha512-7S1Pwq16M4sqvv/op7iHErc6Diz+DXsBYRMS0dDj6HUS44VXMvgejXa3RMd5jwBmcHzkInFm3DW1eb2exBs0cg==",
       "dev": true,
       "license": "MIT"
     },
@@ -1073,9 +1095,9 @@
       "license": "MIT"
     },
     "node_modules/@cspell/dict-python": {
-      "version": "4.2.11",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-python/-/dict-python-4.2.11.tgz",
-      "integrity": "sha512-bshNZqP5FYRO0CtZ9GgtVjHidrSuRRF537MU/sPew8oaqWPg066F9KQfPllbRi9AzFqqeS2l7/ACYUrFMe21gw==",
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-python/-/dict-python-4.2.12.tgz",
+      "integrity": "sha512-U25eOFu+RE0aEcF2AsxZmq3Lic7y9zspJ9SzjrC0mfJz+yr3YmSCw4E0blMD3mZoNcf7H/vMshuKIY5AY36U+Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1097,9 +1119,9 @@
       "license": "MIT"
     },
     "node_modules/@cspell/dict-rust": {
-      "version": "4.0.9",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-rust/-/dict-rust-4.0.9.tgz",
-      "integrity": "sha512-Dhr6TIZsMV92xcikKIWei6p/qswS4M+gTkivpWwz4/1oaVk2nRrxJmCdRoVkJlZkkAc17rjxrS12mpnJZI0iWw==",
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-rust/-/dict-rust-4.0.10.tgz",
+      "integrity": "sha512-6o5C8566VGTTctgcwfF3Iy7314W0oMlFFSQOadQ0OEdJ9Z9ERX/PDimrzP3LGuOrvhtEFoK8pj+BLnunNwRNrw==",
       "dev": true,
       "license": "MIT"
     },
@@ -1111,9 +1133,9 @@
       "license": "MIT"
     },
     "node_modules/@cspell/dict-software-terms": {
-      "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-software-terms/-/dict-software-terms-4.1.10.tgz",
-      "integrity": "sha512-+9PuQ9MHQhlET6Hv1mGcWDh6Rb+StzjBMrjfksDeBHBIVdT66u9uCkaZapIzfgktflY4m9oK7+dEynr+BAxvtQ==",
+      "version": "4.1.17",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-software-terms/-/dict-software-terms-4.1.17.tgz",
+      "integrity": "sha512-QORIk1R5DV8oOQ+oAlUWE7UomaJwUucqu2srrc2+PmkoI6R1fJwwg2uHCPBWlIb4PGDNEdXLv9BAD13H+0wytQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -1139,16 +1161,16 @@
       "license": "MIT"
     },
     "node_modules/@cspell/dict-terraform": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-terraform/-/dict-terraform-1.0.5.tgz",
-      "integrity": "sha512-qH3epPB2d6d5w1l4hR2OsnN8qDQ4P0z6oDB7+YiNH+BoECXv4Z38MIV1H8cxIzD2wkzkt2JTcFYaVW72MDZAlg==",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-terraform/-/dict-terraform-1.0.6.tgz",
+      "integrity": "sha512-Sqm5vGbXuI9hCFcr4w6xWf4Y25J9SdleE/IqfM6RySPnk8lISEmVdax4k6+Kinv9qaxyvnIbUUN4WFLWcBPQAg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@cspell/dict-typescript": {
-      "version": "3.1.9",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-typescript/-/dict-typescript-3.1.9.tgz",
-      "integrity": "sha512-ZtO1/cVWvvR477ftTl2TFR09+IIzXG1rcin8CGYA0FO5WhyDAbn8v3A85QikS158BhTVUoq09lPYuSF9HBzqvw==",
+      "version": "3.1.11",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-typescript/-/dict-typescript-3.1.11.tgz",
+      "integrity": "sha512-FwvK5sKbwrVpdw0e9+1lVTl8FPoHYvfHRuQRQz2Ql5XkC0gwPPkpoyD1zYImjIyZRoYXk3yp9j8ss4iz7A7zoQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -1160,9 +1182,9 @@
       "license": "MIT"
     },
     "node_modules/@cspell/dynamic-import": {
-      "version": "8.15.2",
-      "resolved": "https://registry.npmjs.org/@cspell/dynamic-import/-/dynamic-import-8.15.2.tgz",
-      "integrity": "sha512-37eYzVLqMv3KnY7UMmv/wC9OlUjPC7EJ3xMDourgDTNp6BtiPlMkHRTN5/yvRjukQedi41R1hewgCcZbwSpNXg==",
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/@cspell/dynamic-import/-/dynamic-import-8.16.0.tgz",
+      "integrity": "sha512-FH+B5y71qfunagXiLSJhXP9h/Vwb1Z8Cc/hLmliGekw/Y8BuYknL86tMg9grXBYNmM0kifIv6ZesQl8Km/p/rA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1173,9 +1195,9 @@
       }
     },
     "node_modules/@cspell/filetypes": {
-      "version": "8.15.2",
-      "resolved": "https://registry.npmjs.org/@cspell/filetypes/-/filetypes-8.15.2.tgz",
-      "integrity": "sha512-x2ciWqi6y2RoTcXRTG3BuxAly1TIr4puLzKHkMWtnYp1A++gohCBczMt33FwrwFav0Dfx9M0mCpT1h1ORVwzhA==",
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/@cspell/filetypes/-/filetypes-8.16.0.tgz",
+      "integrity": "sha512-u2Ub0uSwXFPJFvXhAO/0FZBj3sMr4CeYCiQwTUsdFRkRMFpbTc7Vf+a+aC2vIj6WcaWrYXrJy3NZF/yjqF6SGw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1183,9 +1205,9 @@
       }
     },
     "node_modules/@cspell/strong-weak-map": {
-      "version": "8.15.2",
-      "resolved": "https://registry.npmjs.org/@cspell/strong-weak-map/-/strong-weak-map-8.15.2.tgz",
-      "integrity": "sha512-FMz3vgyPJjJsg0f78ToprOxR0lPhZOWwidxD+gOMLLfUzJ0mBC4VwoggrgIF6YEdXy/2UoIUtjh5B/Qfge9IDw==",
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/@cspell/strong-weak-map/-/strong-weak-map-8.16.0.tgz",
+      "integrity": "sha512-R6N12wEIQpBk2uyni/FU1SFSIjP0uql7ynXVcF1ob8/JJeRoikssydi9Xq5J6ghMw+X50u35mFvg9BgWKz0d+g==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1193,9 +1215,9 @@
       }
     },
     "node_modules/@cspell/url": {
-      "version": "8.15.2",
-      "resolved": "https://registry.npmjs.org/@cspell/url/-/url-8.15.2.tgz",
-      "integrity": "sha512-AxS6nqh65V8BJf+ke7XNsDlieXfq/73XjZ4OxQAHvmML9kgXAbTviDcN6ddj6d2fTgU3EOSU1fBfDOqpS4n6Sg==",
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/@cspell/url/-/url-8.16.0.tgz",
+      "integrity": "sha512-zW+6hAieD/FjysfjY4mVv7iHWWasBP3ldj6L+xy2p4Kuax1nug7uuJqMHlAVude/OywNwENG0rYaP/P9Pg4O+w==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4204,30 +4226,30 @@
       }
     },
     "node_modules/cspell": {
-      "version": "8.15.2",
-      "resolved": "https://registry.npmjs.org/cspell/-/cspell-8.15.2.tgz",
-      "integrity": "sha512-2XN6LeBAWyRLPUAcKrJTBftNc50VVVeU/j1GVU07hEun4Q4KZG9CbUT+YaZEnZo8xexVUBfZLtB5YxSImCnBtQ==",
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/cspell/-/cspell-8.16.0.tgz",
+      "integrity": "sha512-U6Up/4nODE+Ca+zqwZXTgBioGuF2JQHLEUIuoRJkJzAZkIBYDqrMXM+zdSL9E39+xb9jAtr9kPAYJf1Eybgi9g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@cspell/cspell-json-reporter": "8.15.2",
-        "@cspell/cspell-pipe": "8.15.2",
-        "@cspell/cspell-types": "8.15.2",
-        "@cspell/dynamic-import": "8.15.2",
-        "@cspell/url": "8.15.2",
+        "@cspell/cspell-json-reporter": "8.16.0",
+        "@cspell/cspell-pipe": "8.16.0",
+        "@cspell/cspell-types": "8.16.0",
+        "@cspell/dynamic-import": "8.16.0",
+        "@cspell/url": "8.16.0",
         "chalk": "^5.3.0",
         "chalk-template": "^1.1.0",
         "commander": "^12.1.0",
-        "cspell-dictionary": "8.15.2",
-        "cspell-gitignore": "8.15.2",
-        "cspell-glob": "8.15.2",
-        "cspell-io": "8.15.2",
-        "cspell-lib": "8.15.2",
+        "cspell-dictionary": "8.16.0",
+        "cspell-gitignore": "8.16.0",
+        "cspell-glob": "8.16.0",
+        "cspell-io": "8.16.0",
+        "cspell-lib": "8.16.0",
         "fast-json-stable-stringify": "^2.1.0",
         "file-entry-cache": "^9.1.0",
         "get-stdin": "^9.0.0",
         "semver": "^7.6.3",
-        "tinyglobby": "^0.2.9"
+        "tinyglobby": "^0.2.10"
       },
       "bin": {
         "cspell": "bin.mjs",
@@ -4241,13 +4263,13 @@
       }
     },
     "node_modules/cspell-config-lib": {
-      "version": "8.15.2",
-      "resolved": "https://registry.npmjs.org/cspell-config-lib/-/cspell-config-lib-8.15.2.tgz",
-      "integrity": "sha512-0vaZdp1gz5mt7RWTWStHHJBXfELtbtJNCl8RNz9E51906bhAyZ/yBvkOyjCW2Ofsdp2cKS11AuzTrq6N2lmK3g==",
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/cspell-config-lib/-/cspell-config-lib-8.16.0.tgz",
+      "integrity": "sha512-PGT6ohLtIYXYLIm+R5hTcTrF0dzj8e7WAUJSJe5WlV/7lrwVdwgWaliLcXtSSPmfxgczr6sndX9TMJ2IEmPrmg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@cspell/cspell-types": "8.15.2",
+        "@cspell/cspell-types": "8.16.0",
         "comment-json": "^4.2.5",
         "yaml": "^2.6.0"
       },
@@ -4256,15 +4278,15 @@
       }
     },
     "node_modules/cspell-dictionary": {
-      "version": "8.15.2",
-      "resolved": "https://registry.npmjs.org/cspell-dictionary/-/cspell-dictionary-8.15.2.tgz",
-      "integrity": "sha512-Kvn8ZD+oQs2KKgGoC601NBju3xQcrP4bz1MVZ23ZN9fm6pukb0J8x9hP3d+AuQd/Cl2XG/y/hWZi6MT92uChIg==",
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/cspell-dictionary/-/cspell-dictionary-8.16.0.tgz",
+      "integrity": "sha512-Y3sN6ttLBKbu0dOLcduY641n5QP1srUvZkW4bOTnG455DbIZfilrP1El/2Hl0RS6hC8LN9PM4bsIm/2xgdbApA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@cspell/cspell-pipe": "8.15.2",
-        "@cspell/cspell-types": "8.15.2",
-        "cspell-trie-lib": "8.15.2",
+        "@cspell/cspell-pipe": "8.16.0",
+        "@cspell/cspell-types": "8.16.0",
+        "cspell-trie-lib": "8.16.0",
         "fast-equals": "^5.0.1"
       },
       "engines": {
@@ -4272,15 +4294,15 @@
       }
     },
     "node_modules/cspell-gitignore": {
-      "version": "8.15.2",
-      "resolved": "https://registry.npmjs.org/cspell-gitignore/-/cspell-gitignore-8.15.2.tgz",
-      "integrity": "sha512-XrQ3iouv2VvvpkL1ygEnOuqY/BGNt0tBZngFrb/Y12LWgcZ6unLZk4IaMYXlmjRZPtq7QuBe4dvG1D2SFcNEng==",
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/cspell-gitignore/-/cspell-gitignore-8.16.0.tgz",
+      "integrity": "sha512-ODKe0ooyzYSBJkwgIVZSRIvzoZfT4tEbFt4fFDT88wPyyfX7xp7MAQhXy5KD1ocXH0WvYbdv37qzn2UbckrahA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@cspell/url": "8.15.2",
-        "cspell-glob": "8.15.2",
-        "cspell-io": "8.15.2",
+        "@cspell/url": "8.16.0",
+        "cspell-glob": "8.16.0",
+        "cspell-io": "8.16.0",
         "find-up-simple": "^1.0.0"
       },
       "bin": {
@@ -4291,13 +4313,13 @@
       }
     },
     "node_modules/cspell-glob": {
-      "version": "8.15.2",
-      "resolved": "https://registry.npmjs.org/cspell-glob/-/cspell-glob-8.15.2.tgz",
-      "integrity": "sha512-AQNskPt3FOF1Z6mc+cvCZ33Xnb+a4cMVZwcLlApc/4uup6OvyEoXNN9IyeHVmloAUPlXadaA79balp3cMj2rWg==",
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/cspell-glob/-/cspell-glob-8.16.0.tgz",
+      "integrity": "sha512-xJSXRHwfENCNFmjpVSEucXY8E3BrpSCA+TukmOYtLyaMKtn6EAwoCpEU7Oj2tZOjdivprPmQ74k4Dqb1RHjIVQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@cspell/url": "8.15.2",
+        "@cspell/url": "8.16.0",
         "micromatch": "^4.0.8"
       },
       "engines": {
@@ -4305,14 +4327,14 @@
       }
     },
     "node_modules/cspell-grammar": {
-      "version": "8.15.2",
-      "resolved": "https://registry.npmjs.org/cspell-grammar/-/cspell-grammar-8.15.2.tgz",
-      "integrity": "sha512-yvCiOlg6G2l+lMWBSmWwnVqIVfDK/uUBzY4WIJQaXWtXRuJ9MdsSEQ3TFd9NgJUhY1gSF8O1zSqeCmfPNuS44g==",
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/cspell-grammar/-/cspell-grammar-8.16.0.tgz",
+      "integrity": "sha512-vvbJEkBqXocGH/H975RtkfMzVpNxNGMd0JCDd+NjbpeRyZceuChFw5Tie7kHteFY29SwZovub+Am3F4H1kmf9A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@cspell/cspell-pipe": "8.15.2",
-        "@cspell/cspell-types": "8.15.2"
+        "@cspell/cspell-pipe": "8.16.0",
+        "@cspell/cspell-types": "8.16.0"
       },
       "bin": {
         "cspell-grammar": "bin.mjs"
@@ -4322,42 +4344,42 @@
       }
     },
     "node_modules/cspell-io": {
-      "version": "8.15.2",
-      "resolved": "https://registry.npmjs.org/cspell-io/-/cspell-io-8.15.2.tgz",
-      "integrity": "sha512-Y4bEsKVXC48VawU+gU1lcsO7B55pNAjc8/C8Qg8UByobSOxtZKd7jaRRqqvd60Rh8lbgG4Nc05zKCb1CxY1+2Q==",
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/cspell-io/-/cspell-io-8.16.0.tgz",
+      "integrity": "sha512-WIK5uhPMjGsTAzm2/fGRbIdr7zWsMVG1fn8wNJYUiYELuyvzvLelfI1VG6szaFCGYqd6Uvgb/fS0uNbwGqCLAQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@cspell/cspell-service-bus": "8.15.2",
-        "@cspell/url": "8.15.2"
+        "@cspell/cspell-service-bus": "8.16.0",
+        "@cspell/url": "8.16.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/cspell-lib": {
-      "version": "8.15.2",
-      "resolved": "https://registry.npmjs.org/cspell-lib/-/cspell-lib-8.15.2.tgz",
-      "integrity": "sha512-u4tO8NoLq/LuOdCBqJdKBLE51uCcE2Ni/DvaEFNfuhk2fCF3rE/2nCzLx6ZEAiFPHZVMs44MJxpH7VF8Rn/T8g==",
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/cspell-lib/-/cspell-lib-8.16.0.tgz",
+      "integrity": "sha512-fU8CfECyuhT12COIi4ViQu2bTkdqaa+05YSd2ZV8k8NA7lapPaMFnlooxdfcwwgZJfHeMhRVMzvQF1OhWmwGfA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@cspell/cspell-bundled-dicts": "8.15.2",
-        "@cspell/cspell-pipe": "8.15.2",
-        "@cspell/cspell-resolver": "8.15.2",
-        "@cspell/cspell-types": "8.15.2",
-        "@cspell/dynamic-import": "8.15.2",
-        "@cspell/filetypes": "8.15.2",
-        "@cspell/strong-weak-map": "8.15.2",
-        "@cspell/url": "8.15.2",
+        "@cspell/cspell-bundled-dicts": "8.16.0",
+        "@cspell/cspell-pipe": "8.16.0",
+        "@cspell/cspell-resolver": "8.16.0",
+        "@cspell/cspell-types": "8.16.0",
+        "@cspell/dynamic-import": "8.16.0",
+        "@cspell/filetypes": "8.16.0",
+        "@cspell/strong-weak-map": "8.16.0",
+        "@cspell/url": "8.16.0",
         "clear-module": "^4.1.2",
         "comment-json": "^4.2.5",
-        "cspell-config-lib": "8.15.2",
-        "cspell-dictionary": "8.15.2",
-        "cspell-glob": "8.15.2",
-        "cspell-grammar": "8.15.2",
-        "cspell-io": "8.15.2",
-        "cspell-trie-lib": "8.15.2",
+        "cspell-config-lib": "8.16.0",
+        "cspell-dictionary": "8.16.0",
+        "cspell-glob": "8.16.0",
+        "cspell-grammar": "8.16.0",
+        "cspell-io": "8.16.0",
+        "cspell-trie-lib": "8.16.0",
         "env-paths": "^3.0.0",
         "fast-equals": "^5.0.1",
         "gensequence": "^7.0.0",
@@ -4372,14 +4394,14 @@
       }
     },
     "node_modules/cspell-trie-lib": {
-      "version": "8.15.2",
-      "resolved": "https://registry.npmjs.org/cspell-trie-lib/-/cspell-trie-lib-8.15.2.tgz",
-      "integrity": "sha512-dqEc4832iareVCA+pXuvdNwtUF+F8S+w15Tlv0fRdPTz8X4wcUtK0R5npYnL5dyuPhKBdO/PmKXGb7/5I0vBMg==",
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/cspell-trie-lib/-/cspell-trie-lib-8.16.0.tgz",
+      "integrity": "sha512-Io1qqI0r4U9ewAWBLClFBBlxLeAoIi15PUGJi4Za1xrlgQJwRE8PMNIJNHKmPEIp78Iute3o/JyC2OfWlxl4Sw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@cspell/cspell-pipe": "8.15.2",
-        "@cspell/cspell-types": "8.15.2",
+        "@cspell/cspell-pipe": "8.16.0",
+        "@cspell/cspell-types": "8.16.0",
         "gensequence": "^7.0.0"
       },
       "engines": {
@@ -5168,9 +5190,9 @@
       }
     },
     "node_modules/eslint-plugin-jest": {
-      "version": "28.8.3",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-28.8.3.tgz",
-      "integrity": "sha512-HIQ3t9hASLKm2IhIOqnu+ifw7uLZkIlR7RYNv7fMcEi/p0CIiJmfriStQS2LDkgtY4nyLbIZAD+JL347Yc2ETQ==",
+      "version": "28.9.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-28.9.0.tgz",
+      "integrity": "sha512-rLu1s1Wf96TgUUxSw6loVIkNtUjq1Re7A9QdCCHSohnvXEBAjuL420h0T/fMmkQlNsQP2GhQzEUpYHPfxBkvYQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5194,9 +5216,9 @@
       }
     },
     "node_modules/eslint-plugin-jsdoc": {
-      "version": "50.4.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-50.4.1.tgz",
-      "integrity": "sha512-OXIq+JJQPCLAKL473/esioFOwbXyRE5MAQ4HbZjcp3e+K3zdxt2uDpGs3FR+WezUXNStzEtTfgx15T+JFrVwBA==",
+      "version": "50.5.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-50.5.0.tgz",
+      "integrity": "sha512-xTkshfZrUbiSHXBwZ/9d5ulZ2OcHXxSvm/NPo494H/hadLRJwOq5PMV0EUpMqsb9V+kQo+9BAgi6Z7aJtdBp2A==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -8643,9 +8665,9 @@
       "license": "MIT"
     },
     "node_modules/logform": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/logform/-/logform-2.6.1.tgz",
-      "integrity": "sha512-CdaO738xRapbKIMVn2m4F6KTj4j7ooJ8POVnebSgKo3KBz5axNXRAL7ZdRjIV6NOr2Uf4vjtRkxrFETOioCqSA==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/logform/-/logform-2.7.0.tgz",
+      "integrity": "sha512-TFYA4jnP7PVbmlBIfhlSe+WKxs9dklXMTEGcBCIvLhE/Tn3H6Gk1norupVW7m5Cnd4bLcr08AytbyV/xj7f/kQ==",
       "license": "MIT",
       "dependencies": {
         "@colors/colors": "1.6.0",
@@ -8986,9 +9008,9 @@
       }
     },
     "node_modules/npm-check-updates": {
-      "version": "17.1.3",
-      "resolved": "https://registry.npmjs.org/npm-check-updates/-/npm-check-updates-17.1.3.tgz",
-      "integrity": "sha512-4uDLBWPuDHT5KLieIJ20FoAB8yqJejmupI42wPyfObgQOBbPAikQSwT73afDwREvhuxYrRDqlRvxTMSfvO+L8A==",
+      "version": "17.1.11",
+      "resolved": "https://registry.npmjs.org/npm-check-updates/-/npm-check-updates-17.1.11.tgz",
+      "integrity": "sha512-TR2RuGIH7P3Qrb0jfdC/nT7JWqXPKjDlxuNQt3kx4oNVf1Pn5SBRB7KLypgYZhruivJthgTtfkkyK4mz342VjA==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -10904,13 +10926,13 @@
       "license": "MIT"
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.9",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.9.tgz",
-      "integrity": "sha512-8or1+BGEdk1Zkkw2ii16qSS7uVrQJPre5A9o/XkWPATkk23FZh/15BKFxPnlTy6vkljZxLqYCzzBMj30ZrSvjw==",
+      "version": "0.2.10",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.10.tgz",
+      "integrity": "sha512-Zc+8eJlFMvgatPZTl6A9L/yht8QqdmUNtURHaKZLmKBE12hNPSrqNkUp2cs3M/UKmNVVAMFQYSjYIVHDjW5zew==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "fdir": "^6.4.0",
+        "fdir": "^6.4.2",
         "picomatch": "^4.0.2"
       },
       "engines": {
@@ -10918,9 +10940,9 @@
       }
     },
     "node_modules/tinyglobby/node_modules/fdir": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.0.tgz",
-      "integrity": "sha512-3oB133prH1o4j/L5lLW7uOCF1PlD+/It2L0eL/iAqWMB91RBbqTewABqxhj0ibBd90EEmWZq7ntIWzVaWcXTGQ==",
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.2.tgz",
+      "integrity": "sha512-KnhMXsKSPZlAhp7+IjUkRZKPb4fUyccpDrdFXbi4QL1qkmFh9kVY09Yox+n4MaOb3lHZ1Tv829C3oaaXoMYPDQ==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
@@ -11616,34 +11638,34 @@
       "license": "MIT"
     },
     "node_modules/winston": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/winston/-/winston-3.15.0.tgz",
-      "integrity": "sha512-RhruH2Cj0bV0WgNL+lOfoUBI4DVfdUNjVnJGVovWZmrcKtrFTTRzgXYK2O9cymSGjrERCtaAeHwMNnUWXlwZow==",
+      "version": "3.17.0",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-3.17.0.tgz",
+      "integrity": "sha512-DLiFIXYC5fMPxaRg832S6F5mJYvePtmO5G9v9IgUFPhXm9/GkXarH/TUrBAVzhTCzAj9anE/+GjrgXp/54nOgw==",
       "license": "MIT",
       "dependencies": {
         "@colors/colors": "^1.6.0",
         "@dabh/diagnostics": "^2.0.2",
         "async": "^3.2.3",
         "is-stream": "^2.0.0",
-        "logform": "^2.6.0",
+        "logform": "^2.7.0",
         "one-time": "^1.0.0",
         "readable-stream": "^3.4.0",
         "safe-stable-stringify": "^2.3.1",
         "stack-trace": "0.0.x",
         "triple-beam": "^1.3.0",
-        "winston-transport": "^4.7.0"
+        "winston-transport": "^4.9.0"
       },
       "engines": {
         "node": ">= 12.0.0"
       }
     },
     "node_modules/winston-transport": {
-      "version": "4.7.1",
-      "resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.7.1.tgz",
-      "integrity": "sha512-wQCXXVgfv/wUPOfb2x0ruxzwkcZfxcktz6JIMUaPLmcNhO4bZTwA/WtDWK74xV3F2dKu8YadrFv0qhwYjVEwhA==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.9.0.tgz",
+      "integrity": "sha512-8drMJ4rkgaPo1Me4zD/3WLfI/zPdA9o2IipKODunnGDcuqbHwjsbB79ylv04LCGGzU0xQ6vTznOMpQGaLhhm6A==",
       "license": "MIT",
       "dependencies": {
-        "logform": "^2.6.1",
+        "logform": "^2.7.0",
         "readable-stream": "^3.6.2",
         "triple-beam": "^1.3.0"
       },
@@ -11788,9 +11810,9 @@
       "license": "ISC"
     },
     "node_modules/yaml": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.6.0.tgz",
-      "integrity": "sha512-a6ae//JvKDEra2kdi1qzCyrJW/WZCgFi8ydDV+eXExl95t+5R+ijnqHJbz9tmMh8FUjx3iv2fCQ4dclAQlO2UQ==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.6.1.tgz",
+      "integrity": "sha512-7r0XPzioN/Q9kXBro/XPnA6kznR73DHq+GXh5ON7ZozRO6aMjbmiBuKste2wslTFkC5d1dw0GooOCepZXJ2SAg==",
       "dev": true,
       "license": "ISC",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -85,23 +85,23 @@
     "express": "^4.21.1",
     "http-terminator": "^3.2.0",
     "node-watch": "^0.7.4",
-    "winston": "^3.15.0",
+    "winston": "^3.17.0",
     "yargs": "^17.7.2"
   },
   "devDependencies": {
     "changelog-light": "^2.0.3",
-    "cspell": "^8.15.2",
+    "cspell": "^8.16.0",
     "eslint": "^8.57.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-babel": "^5.3.1",
     "eslint-plugin-import": "^2.31.0",
-    "eslint-plugin-jest": "^28.8.3",
-    "eslint-plugin-jsdoc": "^50.4.1",
+    "eslint-plugin-jest": "^28.9.0",
+    "eslint-plugin-jsdoc": "^50.5.0",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-prettier": "^5.2.1",
     "jest": "^29.7.0",
     "nodemon": "^3.1.7",
-    "npm-check-updates": "^17.1.3",
+    "npm-check-updates": "^17.1.11",
     "npm-run-all": "^4.1.5",
     "prettier": "^3.3.3"
   }


### PR DESCRIPTION


## What's included
<!-- List your changes/additions, or commits -->
- build(deps): bump group with 5 updates
   * winston from 3.15.0 to 3.17.0
   * cspell from 8.15.2 to 8.16.0
   * eslint-plugin-jest from 28.8.3 to 28.9.0
   * eslint-plugin-jsdoc from 50.4.1 to 50.5.0
   * npm-check-updates from 17.1.3 to 17.1.11

<!-- ### Notes -->
<!-- Anything funky about your updates. Or issues that aren't resolved by this merge request, things of note? -->

## How to test
<!-- Are there directions to test/review? -->

### Coverage and basic unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm test`
1. confirm tests come back clean
<!--
### Interactive unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm run test:dev`
-->

## Example
<!-- Append a demo/screenshot/animated gif, or a link to the aforementioned, of the cli output -->
...

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
ongoing