### PR TITLE
build(deps): bump group with 6 updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "apidoc": "1.2.0",
-        "express": "^4.21.1",
+        "express": "^4.21.2",
         "http-terminator": "^3.2.0",
         "node-watch": "^0.7.4",
         "winston": "^3.17.0",
@@ -20,21 +20,21 @@
         "mock": "bin/cli.js"
       },
       "devDependencies": {
-        "changelog-light": "^2.0.3",
-        "cspell": "^8.16.0",
+        "changelog-light": "^2.0.4",
+        "cspell": "^8.17.1",
         "eslint": "^8.57.0",
         "eslint-config-prettier": "^9.1.0",
         "eslint-plugin-babel": "^5.3.1",
         "eslint-plugin-import": "^2.31.0",
         "eslint-plugin-jest": "^28.9.0",
-        "eslint-plugin-jsdoc": "^50.5.0",
+        "eslint-plugin-jsdoc": "^50.6.1",
         "eslint-plugin-node": "^11.1.0",
         "eslint-plugin-prettier": "^5.2.1",
         "jest": "^29.7.0",
-        "nodemon": "^3.1.7",
+        "nodemon": "^3.1.9",
         "npm-check-updates": "^17.1.11",
         "npm-run-all": "^4.1.5",
-        "prettier": "^3.3.3"
+        "prettier": "^3.4.2"
       },
       "engines": {
         "node": ">=18.0.0"
@@ -580,9 +580,9 @@
       }
     },
     "node_modules/@cspell/cspell-bundled-dicts": {
-      "version": "8.16.0",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-bundled-dicts/-/cspell-bundled-dicts-8.16.0.tgz",
-      "integrity": "sha512-R0Eqq5kTZnmZ0elih5uY3TWjMqqAeMl7ciU7maUs+m1FNjCEdJXtJ9wrQxNgjmXi0tX8cvahZRO3O558tEz/KA==",
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-bundled-dicts/-/cspell-bundled-dicts-8.17.1.tgz",
+      "integrity": "sha512-HmkXS5uX4bk/XxsRS4Q+zRvhgRa81ddGiR2/Xfag9MIi5L5UnEJ4g21EpmIlXkMxYrTu2fp69SZFss5NfcFF9Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -590,8 +590,8 @@
         "@cspell/dict-al": "^1.0.3",
         "@cspell/dict-aws": "^4.0.7",
         "@cspell/dict-bash": "^4.1.8",
-        "@cspell/dict-companies": "^3.1.7",
-        "@cspell/dict-cpp": "^6.0.1",
+        "@cspell/dict-companies": "^3.1.8",
+        "@cspell/dict-cpp": "^6.0.2",
         "@cspell/dict-cryptocurrencies": "^5.0.3",
         "@cspell/dict-csharp": "^4.0.5",
         "@cspell/dict-css": "^4.0.16",
@@ -600,17 +600,17 @@
         "@cspell/dict-docker": "^1.1.11",
         "@cspell/dict-dotnet": "^5.0.8",
         "@cspell/dict-elixir": "^4.0.6",
-        "@cspell/dict-en_us": "^4.3.26",
+        "@cspell/dict-en_us": "^4.3.28",
         "@cspell/dict-en-common-misspellings": "^2.0.7",
         "@cspell/dict-en-gb": "1.1.33",
-        "@cspell/dict-filetypes": "^3.0.8",
+        "@cspell/dict-filetypes": "^3.0.9",
         "@cspell/dict-flutter": "^1.0.3",
         "@cspell/dict-fonts": "^4.0.3",
         "@cspell/dict-fsharp": "^1.0.4",
         "@cspell/dict-fullstack": "^3.2.3",
-        "@cspell/dict-gaming-terms": "^1.0.8",
+        "@cspell/dict-gaming-terms": "^1.0.9",
         "@cspell/dict-git": "^3.0.3",
-        "@cspell/dict-golang": "^6.0.16",
+        "@cspell/dict-golang": "^6.0.17",
         "@cspell/dict-google": "^1.0.4",
         "@cspell/dict-haskell": "^4.0.4",
         "@cspell/dict-html": "^4.0.10",
@@ -625,16 +625,16 @@
         "@cspell/dict-markdown": "^2.0.7",
         "@cspell/dict-monkeyc": "^1.0.9",
         "@cspell/dict-node": "^5.0.5",
-        "@cspell/dict-npm": "^5.1.11",
+        "@cspell/dict-npm": "^5.1.17",
         "@cspell/dict-php": "^4.0.13",
         "@cspell/dict-powershell": "^5.0.13",
         "@cspell/dict-public-licenses": "^2.0.11",
-        "@cspell/dict-python": "^4.2.12",
+        "@cspell/dict-python": "^4.2.13",
         "@cspell/dict-r": "^2.0.4",
         "@cspell/dict-ruby": "^5.0.7",
-        "@cspell/dict-rust": "^4.0.9",
+        "@cspell/dict-rust": "^4.0.10",
         "@cspell/dict-scala": "^5.0.6",
-        "@cspell/dict-software-terms": "^4.1.13",
+        "@cspell/dict-software-terms": "^4.1.19",
         "@cspell/dict-sql": "^2.1.8",
         "@cspell/dict-svelte": "^1.0.5",
         "@cspell/dict-swift": "^2.0.4",
@@ -647,22 +647,22 @@
       }
     },
     "node_modules/@cspell/cspell-json-reporter": {
-      "version": "8.16.0",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-json-reporter/-/cspell-json-reporter-8.16.0.tgz",
-      "integrity": "sha512-KLjPK94gA3JNuWy70LeenJ6EL3SFk2ejERKYJ6SVV/cVOKIvVd2qe42yX3/A/DkF2xzuZ2LD4z0sfoqQL1BaqA==",
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-json-reporter/-/cspell-json-reporter-8.17.1.tgz",
+      "integrity": "sha512-EV9Xkh42Xw3aORvDZfxusICX91DDbqQpYdGKBdPGuhgxWOUYYZKpLXsHCmDkhruMPo2m5gDh++/OqjLRPZofKQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@cspell/cspell-types": "8.16.0"
+        "@cspell/cspell-types": "8.17.1"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@cspell/cspell-pipe": {
-      "version": "8.16.0",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-pipe/-/cspell-pipe-8.16.0.tgz",
-      "integrity": "sha512-WoCgrv/mrtwCY4lhc6vEcqN3AQ7lT6K0NW5ShoSo116U2tRaW0unApIYH4Va8u7T9g3wyspFEceQRR1xD9qb9w==",
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-pipe/-/cspell-pipe-8.17.1.tgz",
+      "integrity": "sha512-uhC99Ox+OH3COSgShv4fpVHiotR70dNvAOSkzRvKVRzV6IGyFnxHjmyVVPEV0dsqzVLxltwYTqFhwI+UOwm45A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -670,9 +670,9 @@
       }
     },
     "node_modules/@cspell/cspell-resolver": {
-      "version": "8.16.0",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-resolver/-/cspell-resolver-8.16.0.tgz",
-      "integrity": "sha512-b+99bph43ptkXlQHgPXSkN/jK6LQHy2zL1Fm9up7+x6Yr64bxAzWzoeqJAPtnrPvFuOrFN0jZasZzKBw8CvrrQ==",
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-resolver/-/cspell-resolver-8.17.1.tgz",
+      "integrity": "sha512-XEK2ymTdQNgsV3ny60VkKzWskbICl4zNXh/DbxsoRXHqIRg43MXFpTNkEJ7j873EqdX7BU4opQQ+5D4stWWuhQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -683,9 +683,9 @@
       }
     },
     "node_modules/@cspell/cspell-service-bus": {
-      "version": "8.16.0",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-service-bus/-/cspell-service-bus-8.16.0.tgz",
-      "integrity": "sha512-+fn763JKA4EYCOv+1VShFq015UMEBAFRDr+rlCnesgLE0fv9TSFVLsjOfh9/g6GuGQLCRLUqKztwwuueeErstQ==",
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-service-bus/-/cspell-service-bus-8.17.1.tgz",
+      "integrity": "sha512-2sFWQtMEWZ4tdz7bw0bAx4NaV1t0ynGfjpuKWdQppsJFKNb+ZPZZ6Ah1dC13AdRRMZaG194kDRFwzNvRaCgWkQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -693,9 +693,9 @@
       }
     },
     "node_modules/@cspell/cspell-types": {
-      "version": "8.16.0",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-types/-/cspell-types-8.16.0.tgz",
-      "integrity": "sha512-bGrIK7p4NVsK+QX/CYWmjax+FkzfSIZaIaoiBESGV5gmwgXDVRMJ3IP6tQVAmTtckOYHCmtT5CZgI8zXWr8dHQ==",
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-types/-/cspell-types-8.17.1.tgz",
+      "integrity": "sha512-NJbov7Jp57fh8addoxesjb8atg/APQfssCH5Q9uZuHBN06wEJDgs7fhfE48bU+RBViC9gltblsYZzZZQKzHYKg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -731,9 +731,9 @@
       "license": "MIT"
     },
     "node_modules/@cspell/dict-companies": {
-      "version": "3.1.7",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-companies/-/dict-companies-3.1.7.tgz",
-      "integrity": "sha512-ncVs/efuAkP1/tLDhWbXukBjgZ5xOUfe03neHMWsE8zvXXc5+Lw6TX5jaJXZLOoES/f4j4AhRE20jsPCF5pm+A==",
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-companies/-/dict-companies-3.1.9.tgz",
+      "integrity": "sha512-w7XEJ2B6x2jq9ws5XNyYgpYj2MxdZ3jW3PETLxjK7nc8pulCFmaGVgZ0JTnDWfJ3QMOczoagn5f9LM2PZ/CuJg==",
       "dev": true,
       "license": "MIT"
     },
@@ -808,9 +808,9 @@
       "license": "MIT"
     },
     "node_modules/@cspell/dict-en_us": {
-      "version": "4.3.27",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-en_us/-/dict-en_us-4.3.27.tgz",
-      "integrity": "sha512-7JYHahRWpi0VykWFTSM03KL/0fs6YtYfpOaTAg4N/d0wB2GfwVG/FJ/SBCjD4LBc6Rx9dzdo95Hs4BB8GPQbOA==",
+      "version": "4.3.28",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-en_us/-/dict-en_us-4.3.28.tgz",
+      "integrity": "sha512-BN1PME7cOl7DXRQJ92pEd1f0Xk5sqjcDfThDGkKcsgwbSOY7KnTc/czBW6Pr3WXIchIm6cT12KEfjNqx7U7Rrw==",
       "dev": true,
       "license": "MIT"
     },
@@ -829,9 +829,9 @@
       "license": "MIT"
     },
     "node_modules/@cspell/dict-filetypes": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-filetypes/-/dict-filetypes-3.0.8.tgz",
-      "integrity": "sha512-D3N8sm/iptzfVwsib/jvpX+K/++rM8SRpLDFUaM4jxm8EyGmSIYRbKZvdIv5BkAWmMlTWoRqlLn7Yb1b11jKJg==",
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-filetypes/-/dict-filetypes-3.0.9.tgz",
+      "integrity": "sha512-U7ycC1cE32A5aEgwzp/iE0TVabonUFnVt+Ygbf6NsIWqEuFWZgZChC7gfztA4T1fpuj602nFdp7eOnTWKORsnQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -864,9 +864,9 @@
       "license": "MIT"
     },
     "node_modules/@cspell/dict-gaming-terms": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-gaming-terms/-/dict-gaming-terms-1.0.8.tgz",
-      "integrity": "sha512-7OL0zTl93WFWhhtpXFrtm9uZXItC3ncAs8d0iQDMMFVNU1rBr6raBNxJskxE5wx2Ant12fgI66ZGVagXfN+yfA==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-gaming-terms/-/dict-gaming-terms-1.0.9.tgz",
+      "integrity": "sha512-AVIrZt3YiUnxsUzzGYTZ1XqgtkgwGEO0LWIlEf+SiDUEVLtv4CYmmyXFQ+WXDN0pyJ0wOwDazWrP0Cu7avYQmQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -989,9 +989,9 @@
       "license": "MIT"
     },
     "node_modules/@cspell/dict-npm": {
-      "version": "5.1.13",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-npm/-/dict-npm-5.1.13.tgz",
-      "integrity": "sha512-7S1Pwq16M4sqvv/op7iHErc6Diz+DXsBYRMS0dDj6HUS44VXMvgejXa3RMd5jwBmcHzkInFm3DW1eb2exBs0cg==",
+      "version": "5.1.18",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-npm/-/dict-npm-5.1.18.tgz",
+      "integrity": "sha512-/Nukl+DSxtEWSlb8svWFSpJVctAsM9SP+f5Q1n+qdDcXNKMb1bUCo/d3QZPwyOhuMjDawnsGBUAfp+iq7Mw83Q==",
       "dev": true,
       "license": "MIT"
     },
@@ -1017,9 +1017,9 @@
       "license": "MIT"
     },
     "node_modules/@cspell/dict-python": {
-      "version": "4.2.12",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-python/-/dict-python-4.2.12.tgz",
-      "integrity": "sha512-U25eOFu+RE0aEcF2AsxZmq3Lic7y9zspJ9SzjrC0mfJz+yr3YmSCw4E0blMD3mZoNcf7H/vMshuKIY5AY36U+Q==",
+      "version": "4.2.13",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-python/-/dict-python-4.2.13.tgz",
+      "integrity": "sha512-mZIcmo9qif8LkJ6N/lqTZawcOk2kVTcuWIUOSbMcjyomO0XZ7iWz15TfONyr03Ea/l7o5ULV+MZ4vx76bAUb7w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1055,9 +1055,9 @@
       "license": "MIT"
     },
     "node_modules/@cspell/dict-software-terms": {
-      "version": "4.1.17",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-software-terms/-/dict-software-terms-4.1.17.tgz",
-      "integrity": "sha512-QORIk1R5DV8oOQ+oAlUWE7UomaJwUucqu2srrc2+PmkoI6R1fJwwg2uHCPBWlIb4PGDNEdXLv9BAD13H+0wytQ==",
+      "version": "4.1.20",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-software-terms/-/dict-software-terms-4.1.20.tgz",
+      "integrity": "sha512-ma51njqbk9ZKzZF9NpCZpZ+c50EwR5JTJ2LEXlX0tX+ExVbKpthhlDLhT2+mkUh5Zvj+CLf5F9z0qB4+X3re/w==",
       "dev": true,
       "license": "MIT"
     },
@@ -1104,12 +1104,13 @@
       "license": "MIT"
     },
     "node_modules/@cspell/dynamic-import": {
-      "version": "8.16.0",
-      "resolved": "https://registry.npmjs.org/@cspell/dynamic-import/-/dynamic-import-8.16.0.tgz",
-      "integrity": "sha512-FH+B5y71qfunagXiLSJhXP9h/Vwb1Z8Cc/hLmliGekw/Y8BuYknL86tMg9grXBYNmM0kifIv6ZesQl8Km/p/rA==",
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/@cspell/dynamic-import/-/dynamic-import-8.17.1.tgz",
+      "integrity": "sha512-XQtr2olYOtqbg49E+8SISd6I5DzfxmsKINDn0ZgaTFeLalnNdF3ewDU4gOEbApIzGffRa1mW9t19MsiVrznSDw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
+        "@cspell/url": "8.17.1",
         "import-meta-resolve": "^4.1.0"
       },
       "engines": {
@@ -1117,9 +1118,9 @@
       }
     },
     "node_modules/@cspell/filetypes": {
-      "version": "8.16.0",
-      "resolved": "https://registry.npmjs.org/@cspell/filetypes/-/filetypes-8.16.0.tgz",
-      "integrity": "sha512-u2Ub0uSwXFPJFvXhAO/0FZBj3sMr4CeYCiQwTUsdFRkRMFpbTc7Vf+a+aC2vIj6WcaWrYXrJy3NZF/yjqF6SGw==",
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/@cspell/filetypes/-/filetypes-8.17.1.tgz",
+      "integrity": "sha512-AxYw6j7EPYtDFAFjwybjFpMc9waXQzurfBXmEVfQ5RQRlbylujLZWwR6GnMqofeNg4oGDUpEjcAZFrgdkvMQlA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1127,9 +1128,9 @@
       }
     },
     "node_modules/@cspell/strong-weak-map": {
-      "version": "8.16.0",
-      "resolved": "https://registry.npmjs.org/@cspell/strong-weak-map/-/strong-weak-map-8.16.0.tgz",
-      "integrity": "sha512-R6N12wEIQpBk2uyni/FU1SFSIjP0uql7ynXVcF1ob8/JJeRoikssydi9Xq5J6ghMw+X50u35mFvg9BgWKz0d+g==",
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/@cspell/strong-weak-map/-/strong-weak-map-8.17.1.tgz",
+      "integrity": "sha512-8cY3vLAKdt5gQEMM3Gr57BuQ8sun2NjYNh9qTdrctC1S9gNC7XzFghTYAfHSWR4VrOUcMFLO/izMdsc1KFvFOA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1137,9 +1138,9 @@
       }
     },
     "node_modules/@cspell/url": {
-      "version": "8.16.0",
-      "resolved": "https://registry.npmjs.org/@cspell/url/-/url-8.16.0.tgz",
-      "integrity": "sha512-zW+6hAieD/FjysfjY4mVv7iHWWasBP3ldj6L+xy2p4Kuax1nug7uuJqMHlAVude/OywNwENG0rYaP/P9Pg4O+w==",
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/@cspell/url/-/url-8.17.1.tgz",
+      "integrity": "sha512-LMvReIndW1ckvemElfDgTt282fb2C3C/ZXfsm0pJsTV5ZmtdelCHwzmgSBmY5fDr7D66XDp8EurotSE0K6BTvw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3725,9 +3726,9 @@
       }
     },
     "node_modules/changelog-light": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/changelog-light/-/changelog-light-2.0.3.tgz",
-      "integrity": "sha512-l2EpqUfoOY1mKaTNrmeJ+hi8ExlYeHFfPL6/6lO0kKphWILQo9Ehm52Lehm3NrrWT4g4yOewvgmWtRXzduHvBQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/changelog-light/-/changelog-light-2.0.4.tgz",
+      "integrity": "sha512-SomUarreEcEiYyo9RPCF7O6KjnHQc7KU3QNpuoSlhdFLCn+V7wEAyAe0p6q/Hu/4I7BonD6pLBtD6tkHN5VNMA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4123,25 +4124,25 @@
       }
     },
     "node_modules/cspell": {
-      "version": "8.16.0",
-      "resolved": "https://registry.npmjs.org/cspell/-/cspell-8.16.0.tgz",
-      "integrity": "sha512-U6Up/4nODE+Ca+zqwZXTgBioGuF2JQHLEUIuoRJkJzAZkIBYDqrMXM+zdSL9E39+xb9jAtr9kPAYJf1Eybgi9g==",
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/cspell/-/cspell-8.17.1.tgz",
+      "integrity": "sha512-D0lw8XTXrTycNzOn5DkfPJNUT00X53OgvFDm+0SzhBr1r+na8LEh3CnQ6zKYVU0fL0x8vU82vs4jmGjDho9mPg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@cspell/cspell-json-reporter": "8.16.0",
-        "@cspell/cspell-pipe": "8.16.0",
-        "@cspell/cspell-types": "8.16.0",
-        "@cspell/dynamic-import": "8.16.0",
-        "@cspell/url": "8.16.0",
+        "@cspell/cspell-json-reporter": "8.17.1",
+        "@cspell/cspell-pipe": "8.17.1",
+        "@cspell/cspell-types": "8.17.1",
+        "@cspell/dynamic-import": "8.17.1",
+        "@cspell/url": "8.17.1",
         "chalk": "^5.3.0",
         "chalk-template": "^1.1.0",
         "commander": "^12.1.0",
-        "cspell-dictionary": "8.16.0",
-        "cspell-gitignore": "8.16.0",
-        "cspell-glob": "8.16.0",
-        "cspell-io": "8.16.0",
-        "cspell-lib": "8.16.0",
+        "cspell-dictionary": "8.17.1",
+        "cspell-gitignore": "8.17.1",
+        "cspell-glob": "8.17.1",
+        "cspell-io": "8.17.1",
+        "cspell-lib": "8.17.1",
         "fast-json-stable-stringify": "^2.1.0",
         "file-entry-cache": "^9.1.0",
         "get-stdin": "^9.0.0",
@@ -4160,30 +4161,30 @@
       }
     },
     "node_modules/cspell-config-lib": {
-      "version": "8.16.0",
-      "resolved": "https://registry.npmjs.org/cspell-config-lib/-/cspell-config-lib-8.16.0.tgz",
-      "integrity": "sha512-PGT6ohLtIYXYLIm+R5hTcTrF0dzj8e7WAUJSJe5WlV/7lrwVdwgWaliLcXtSSPmfxgczr6sndX9TMJ2IEmPrmg==",
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/cspell-config-lib/-/cspell-config-lib-8.17.1.tgz",
+      "integrity": "sha512-x1S7QWprgUcwuwiJB1Ng0ZTBC4G50qP9qQyg/aroMkcdMsHfk26E8jUGRPNt4ftHFzS4YMhwtXuJQ9IgRUuNPA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@cspell/cspell-types": "8.16.0",
+        "@cspell/cspell-types": "8.17.1",
         "comment-json": "^4.2.5",
-        "yaml": "^2.6.0"
+        "yaml": "^2.6.1"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/cspell-dictionary": {
-      "version": "8.16.0",
-      "resolved": "https://registry.npmjs.org/cspell-dictionary/-/cspell-dictionary-8.16.0.tgz",
-      "integrity": "sha512-Y3sN6ttLBKbu0dOLcduY641n5QP1srUvZkW4bOTnG455DbIZfilrP1El/2Hl0RS6hC8LN9PM4bsIm/2xgdbApA==",
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/cspell-dictionary/-/cspell-dictionary-8.17.1.tgz",
+      "integrity": "sha512-zSl9l3wii+x16yc2NVZl/+CMLeLBAiuEd5YoFkOYPcbTJnfPwdjMNcj71u7wBvNJ+qwbF+kGbutEt15yHW3NBw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@cspell/cspell-pipe": "8.16.0",
-        "@cspell/cspell-types": "8.16.0",
-        "cspell-trie-lib": "8.16.0",
+        "@cspell/cspell-pipe": "8.17.1",
+        "@cspell/cspell-types": "8.17.1",
+        "cspell-trie-lib": "8.17.1",
         "fast-equals": "^5.0.1"
       },
       "engines": {
@@ -4191,15 +4192,15 @@
       }
     },
     "node_modules/cspell-gitignore": {
-      "version": "8.16.0",
-      "resolved": "https://registry.npmjs.org/cspell-gitignore/-/cspell-gitignore-8.16.0.tgz",
-      "integrity": "sha512-ODKe0ooyzYSBJkwgIVZSRIvzoZfT4tEbFt4fFDT88wPyyfX7xp7MAQhXy5KD1ocXH0WvYbdv37qzn2UbckrahA==",
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/cspell-gitignore/-/cspell-gitignore-8.17.1.tgz",
+      "integrity": "sha512-bk727Zf4FBCjm9Mwvyreyhgjwe+YhPQEW7PldkHiinKd+Irfez4s8GXLQb1EgV0UpvViqaqBqLmngjZdS30BTA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@cspell/url": "8.16.0",
-        "cspell-glob": "8.16.0",
-        "cspell-io": "8.16.0",
+        "@cspell/url": "8.17.1",
+        "cspell-glob": "8.17.1",
+        "cspell-io": "8.17.1",
         "find-up-simple": "^1.0.0"
       },
       "bin": {
@@ -4210,13 +4211,13 @@
       }
     },
     "node_modules/cspell-glob": {
-      "version": "8.16.0",
-      "resolved": "https://registry.npmjs.org/cspell-glob/-/cspell-glob-8.16.0.tgz",
-      "integrity": "sha512-xJSXRHwfENCNFmjpVSEucXY8E3BrpSCA+TukmOYtLyaMKtn6EAwoCpEU7Oj2tZOjdivprPmQ74k4Dqb1RHjIVQ==",
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/cspell-glob/-/cspell-glob-8.17.1.tgz",
+      "integrity": "sha512-cUwM5auSt0RvLX7UkP2GEArJRWc85l51B1voArl+3ZIKeMZwcJpJgN3qvImtF8yRTZwYeYCs1sgsihb179q+mg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@cspell/url": "8.16.0",
+        "@cspell/url": "8.17.1",
         "micromatch": "^4.0.8"
       },
       "engines": {
@@ -4224,14 +4225,14 @@
       }
     },
     "node_modules/cspell-grammar": {
-      "version": "8.16.0",
-      "resolved": "https://registry.npmjs.org/cspell-grammar/-/cspell-grammar-8.16.0.tgz",
-      "integrity": "sha512-vvbJEkBqXocGH/H975RtkfMzVpNxNGMd0JCDd+NjbpeRyZceuChFw5Tie7kHteFY29SwZovub+Am3F4H1kmf9A==",
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/cspell-grammar/-/cspell-grammar-8.17.1.tgz",
+      "integrity": "sha512-H5tLcBuW7aUj9L0rR+FSbnWPEsWb8lWppHVidtqw9Ll1CUHWOZC9HTB2RdrhJZrsz/8DJbM2yNbok0Xt0VAfdw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@cspell/cspell-pipe": "8.16.0",
-        "@cspell/cspell-types": "8.16.0"
+        "@cspell/cspell-pipe": "8.17.1",
+        "@cspell/cspell-types": "8.17.1"
       },
       "bin": {
         "cspell-grammar": "bin.mjs"
@@ -4241,42 +4242,42 @@
       }
     },
     "node_modules/cspell-io": {
-      "version": "8.16.0",
-      "resolved": "https://registry.npmjs.org/cspell-io/-/cspell-io-8.16.0.tgz",
-      "integrity": "sha512-WIK5uhPMjGsTAzm2/fGRbIdr7zWsMVG1fn8wNJYUiYELuyvzvLelfI1VG6szaFCGYqd6Uvgb/fS0uNbwGqCLAQ==",
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/cspell-io/-/cspell-io-8.17.1.tgz",
+      "integrity": "sha512-liIOsblt7oVItifzRAbuxiYrwlgw1VOqKppMxVKtYoAn2VUuuEpjCj6jLWpoTqSszR/38o7ChsHY1LHakhJZmw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@cspell/cspell-service-bus": "8.16.0",
-        "@cspell/url": "8.16.0"
+        "@cspell/cspell-service-bus": "8.17.1",
+        "@cspell/url": "8.17.1"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/cspell-lib": {
-      "version": "8.16.0",
-      "resolved": "https://registry.npmjs.org/cspell-lib/-/cspell-lib-8.16.0.tgz",
-      "integrity": "sha512-fU8CfECyuhT12COIi4ViQu2bTkdqaa+05YSd2ZV8k8NA7lapPaMFnlooxdfcwwgZJfHeMhRVMzvQF1OhWmwGfA==",
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/cspell-lib/-/cspell-lib-8.17.1.tgz",
+      "integrity": "sha512-66n83Q7bK5tnvkDH7869/pBY/65AKmZVfCOAlsbhJn3YMDbNHFCHR0d1oNMlqG+n65Aco89VGwYfXxImZY+/mA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@cspell/cspell-bundled-dicts": "8.16.0",
-        "@cspell/cspell-pipe": "8.16.0",
-        "@cspell/cspell-resolver": "8.16.0",
-        "@cspell/cspell-types": "8.16.0",
-        "@cspell/dynamic-import": "8.16.0",
-        "@cspell/filetypes": "8.16.0",
-        "@cspell/strong-weak-map": "8.16.0",
-        "@cspell/url": "8.16.0",
+        "@cspell/cspell-bundled-dicts": "8.17.1",
+        "@cspell/cspell-pipe": "8.17.1",
+        "@cspell/cspell-resolver": "8.17.1",
+        "@cspell/cspell-types": "8.17.1",
+        "@cspell/dynamic-import": "8.17.1",
+        "@cspell/filetypes": "8.17.1",
+        "@cspell/strong-weak-map": "8.17.1",
+        "@cspell/url": "8.17.1",
         "clear-module": "^4.1.2",
         "comment-json": "^4.2.5",
-        "cspell-config-lib": "8.16.0",
-        "cspell-dictionary": "8.16.0",
-        "cspell-glob": "8.16.0",
-        "cspell-grammar": "8.16.0",
-        "cspell-io": "8.16.0",
-        "cspell-trie-lib": "8.16.0",
+        "cspell-config-lib": "8.17.1",
+        "cspell-dictionary": "8.17.1",
+        "cspell-glob": "8.17.1",
+        "cspell-grammar": "8.17.1",
+        "cspell-io": "8.17.1",
+        "cspell-trie-lib": "8.17.1",
         "env-paths": "^3.0.0",
         "fast-equals": "^5.0.1",
         "gensequence": "^7.0.0",
@@ -4291,14 +4292,14 @@
       }
     },
     "node_modules/cspell-trie-lib": {
-      "version": "8.16.0",
-      "resolved": "https://registry.npmjs.org/cspell-trie-lib/-/cspell-trie-lib-8.16.0.tgz",
-      "integrity": "sha512-Io1qqI0r4U9ewAWBLClFBBlxLeAoIi15PUGJi4Za1xrlgQJwRE8PMNIJNHKmPEIp78Iute3o/JyC2OfWlxl4Sw==",
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/cspell-trie-lib/-/cspell-trie-lib-8.17.1.tgz",
+      "integrity": "sha512-13WNa5s75VwOjlGzWprmfNbBFIfXyA7tYYrbV+LugKkznyNZJeJPojHouEudcLq3SYb2Q6tJ7qyWcuT5bR9qPA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@cspell/cspell-pipe": "8.16.0",
-        "@cspell/cspell-types": "8.16.0",
+        "@cspell/cspell-pipe": "8.17.1",
+        "@cspell/cspell-types": "8.17.1",
         "gensequence": "^7.0.0"
       },
       "engines": {
@@ -5114,9 +5115,9 @@
       }
     },
     "node_modules/eslint-plugin-jsdoc": {
-      "version": "50.5.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-50.5.0.tgz",
-      "integrity": "sha512-xTkshfZrUbiSHXBwZ/9d5ulZ2OcHXxSvm/NPo494H/hadLRJwOq5PMV0EUpMqsb9V+kQo+9BAgi6Z7aJtdBp2A==",
+      "version": "50.6.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-50.6.1.tgz",
+      "integrity": "sha512-UWyaYi6iURdSfdVVqvfOs2vdCVz0J40O/z/HTsv2sFjdjmdlUI/qlKLOTmwbPQ2tAfQnE5F9vqx+B+poF71DBQ==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -5540,9 +5541,9 @@
       }
     },
     "node_modules/express": {
-      "version": "4.21.1",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.21.1.tgz",
-      "integrity": "sha512-YSFlK1Ee0/GC8QaO91tHcDxJiE/X4FbpAyQWkxAvG6AXCuR65YzK8ua6D9hvi/TzUfZMpc+BwuM1IPw8fmQBiQ==",
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.21.2.tgz",
+      "integrity": "sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==",
       "license": "MIT",
       "dependencies": {
         "accepts": "~1.3.8",
@@ -5564,7 +5565,7 @@
         "methods": "~1.1.2",
         "on-finished": "2.4.1",
         "parseurl": "~1.3.3",
-        "path-to-regexp": "0.1.10",
+        "path-to-regexp": "0.1.12",
         "proxy-addr": "~2.0.7",
         "qs": "6.13.0",
         "range-parser": "~1.2.1",
@@ -5579,6 +5580,10 @@
       },
       "engines": {
         "node": ">= 0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/express/node_modules/debug": {
@@ -8903,9 +8908,9 @@
       }
     },
     "node_modules/nodemon": {
-      "version": "3.1.7",
-      "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-3.1.7.tgz",
-      "integrity": "sha512-hLj7fuMow6f0lbB0cD14Lz2xNjwsyruH251Pk4t/yIitCFJbmY1myuLlHm/q06aST4jg6EgAh74PIBBrRqpVAQ==",
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-3.1.9.tgz",
+      "integrity": "sha512-hdr1oIb2p6ZSxu3PB2JWWYS7ZQ0qvaZsc3hK8DR8f02kRzc8rjYmxAIvdz+aYC+8F2IjNaB7HMcSDg8nQpJxyg==",
       "license": "MIT",
       "dependencies": {
         "chokidar": "^3.5.2",
@@ -9481,9 +9486,9 @@
       "license": "MIT"
     },
     "node_modules/path-to-regexp": {
-      "version": "0.1.10",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.10.tgz",
-      "integrity": "sha512-7lf7qcQidTku0Gu3YDPc8DJ1q7OOucfa/BSsIwjuh56VU7katFvuM8hULfkwB3Fns/rsVF7PwPKVw1sl5KQS9w==",
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
+      "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
       "license": "MIT"
     },
     "node_modules/path-type": {
@@ -9635,9 +9640,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.3.tgz",
-      "integrity": "sha512-i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.4.2.tgz",
+      "integrity": "sha512-e9MewbtFo+Fevyuxn/4rrcDAaq0IYxPGLvObpQjiZBMAzB9IGmzlnG9RZy3FFas+eBMu2vA0CszMeduow5dIuQ==",
       "dev": true,
       "license": "MIT",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -82,27 +82,27 @@
   },
   "dependencies": {
     "apidoc": "1.2.0",
-    "express": "^4.21.1",
+    "express": "^4.21.2",
     "http-terminator": "^3.2.0",
     "node-watch": "^0.7.4",
     "winston": "^3.17.0",
     "yargs": "^17.7.2"
   },
   "devDependencies": {
-    "changelog-light": "^2.0.3",
-    "cspell": "^8.16.0",
+    "changelog-light": "^2.0.4",
+    "cspell": "^8.17.1",
     "eslint": "^8.57.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-babel": "^5.3.1",
     "eslint-plugin-import": "^2.31.0",
     "eslint-plugin-jest": "^28.9.0",
-    "eslint-plugin-jsdoc": "^50.5.0",
+    "eslint-plugin-jsdoc": "^50.6.1",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-prettier": "^5.2.1",
     "jest": "^29.7.0",
-    "nodemon": "^3.1.7",
+    "nodemon": "^3.1.9",
     "npm-check-updates": "^17.1.11",
     "npm-run-all": "^4.1.5",
-    "prettier": "^3.3.3"
+    "prettier": "^3.4.2"
   }
 }


### PR DESCRIPTION


## What's included
<!-- List your changes/additions, or commits -->
- build(deps): bump group with 6 updates
   * express from 4.21.1 to 4.21.2
   * changelog-light from 2.0.3 to 2.0.4
   * cspell from 8.16.0 to 8.17.1
   * eslint-plugin-jsdoc from 50.5.0 to 50.6.1
   * nodemon from 3.1.7 to 3.1.9
   * prettier from 3.3.3 to 3.4.2

<!-- ### Notes -->
<!-- Anything funky about your updates. Or issues that aren't resolved by this merge request, things of note? -->

## How to test
<!-- Are there directions to test/review? -->

### Coverage and basic unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm test`
1. confirm tests come back clean
<!--
### Interactive unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm run test:dev`
-->

## Example
<!-- Append a demo/screenshot/animated gif, or a link to the aforementioned, of the cli output -->
...

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
ongoing