### PR TITLE
build(nodejs)!: remove 20 support

### DIFF
--- a/.github/workflows/commit_lint.yml
+++ b/.github/workflows/commit_lint.yml
@@ -11,7 +11,7 @@ jobs:
       contents: read
     strategy:
       matrix:
-        node-version: [22.x]
+        node-version: [24.x]
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -29,7 +29,7 @@ jobs:
     strategy:
       matrix:
         # Coverage node version
-        node-version: [22.x]
+        node-version: [24.x]
     steps:
       - uses: actions/checkout@v6
       - uses: actions/configure-pages@v5

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -11,7 +11,7 @@ jobs:
       contents: read
     strategy:
       matrix:
-        node-version: [20.x, 22.x, 24.x]
+        node-version: [22.x, 24.x]
     steps:
       - uses: actions/checkout@v6
       - name: Setup Node.js ${{ matrix.node-version }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20-alpine
+FROM node:24-alpine
 
 WORKDIR /app
 
@@ -11,4 +11,5 @@ VOLUME /docs
 RUN yarn --production --non-interactive \
     && yarn cache clean
 
+# For 26-alpine review yarn cmd
 CMD ["yarn", "start"]

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ a delay to see how your codebase will handle loading scenarios with a balls slow
 
 ## Requirements
 The basic requirements:
- * [NodeJS version 20+](https://nodejs.org/)
+ * [NodeJS version 22+](https://nodejs.org/)
  * Optionally your system could be running
     - [Docker](https://docs.docker.com/engine/installation/)
     - [podman](https://github.com/containers/podman) or [podman desktop](https://podman-desktop.io/)

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "nodemon": "^3.1.14"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=22.0.0"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "server"
   ],
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.0.0"
   },
   "files": [
     "data/*",


### PR DESCRIPTION
## What's included
<!-- List your changes/additions, or commits -->
- build(nodejs)!: remove 20 support

### Notes
- drop support for Node.js 20. this is a breaking change and will bump the package a semver major
- update related required workflow checks
<!-- Anything funky about your updates. Or issues that aren't resolved by this merge request, things of note? -->

## How to test
<!-- Are there directions to test/review? -->
<!--
### Coverage and basic unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm test`
-->
<!--
### Interactive unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm run test:dev`
-->

## Example
<!-- Append a demo/screenshot/animated gif, or a link to the aforementioned, of the cli output -->
...

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
ongoing